### PR TITLE
Escape nickname (.->_) to work around a swagger UI issue where the jQuer...

### DIFF
--- a/ext/swagger.js
+++ b/ext/swagger.js
@@ -105,7 +105,7 @@ function routeToAPI(route) {
     path: convertPathFragments(route.path),
     operations: [{
       httpMethod: convertVerb(route.verb),
-      nickname: route.method,
+      nickname: route.method.replace('.', '_'), // [rfeng] Swagger UI doesn't escape '.' for jQuery selector
       responseClass: returnDesc ? returnDesc.model || prepareDataType(returnDesc.type) : 'void',
       parameters: route.accepts ? route.accepts.map(acceptToParameter(route)) : [],
       errorResponses: [], // TODO(schoon) - We don't have descriptions for this yet.


### PR DESCRIPTION
Swagger UI builds elements using model nickname as part of the id. To use jQuery selector, special chars such as '.' needed to be escaped. Swagger UI doesn't handle that at this moment. The PR creates a workaround by replacing . with _.
