### PR TITLE
Keep the undefined arguments to match method.accepts

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -81,6 +81,8 @@ SharedMethod.prototype.invoke = function (scope, args, fn) {
         if(desc.required) {
           throw new Error(name + ' is a required arg');
         } else {
+          // Add the argument even if it's undefined to stick with the accepts
+          formattedArgs.push(undefined);
           return;
         }
       }
@@ -101,7 +103,8 @@ SharedMethod.prototype.invoke = function (scope, args, fn) {
         }
       }
 
-      if(actualType !== 'undefined') formattedArgs.push(uarg);
+      // Add the argument even if it's undefined to stick with the accepts
+      formattedArgs.push(uarg);
     });
   }
 


### PR DESCRIPTION
@ritch This patch adds back the 'undefined' argument to match method.accepts so that the implementation sees the same number of arguments in order.
