### PR TITLE
Better error handling

### DIFF
--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -105,7 +105,6 @@ RestAdapter.prototype.createHandler = function () {
   // Set strict to be `false` so that anything `JSON.parse()` accepts will be parsed
   root.use(express.urlencoded());
   root.use(express.json({strict: false}));
-  // TODO(schoon) - Translate into appropriate error codes: 400, 500, etc.
   root.use(express.errorHandler());
   root.use(cors());
 
@@ -181,13 +180,20 @@ RestAdapter.prototype.createHandler = function () {
     });
 
     app.use(function (err, req, res, next) {
+      if(typeof err === 'string') {
+        err = new Error(err);
+        err.statusCode = 500;
+      }
+
       if(err && err.statusCode) {
         res.statusCode = err.statusCode;
+      } else {
+        res.statusCode = 500;
       }
 
       debug('Error in %s %s: %s', req.method, req.url, err.message);
       res.send({
-        error: err.message
+        error: err.message || 'An unknown error occured'
       });
     });
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -182,29 +182,63 @@ describe('strong-remoting', function(){
           });
       });
 
-        it('should allow empty body for json request', function(done) {
-            remotes.foo = {
-                bar: function (a, b, fn) {
-                    fn(null, a, b);
-                }
-            };
+      it('should allow empty body for json request', function(done) {
+          remotes.foo = {
+              bar: function (a, b, fn) {
+                  fn(null, a, b);
+              }
+          };
 
-            var fn = remotes.foo.bar;
+          var fn = remotes.foo.bar;
 
-            fn.shared = true;
-            fn.accepts = [
-                {arg: 'a', type: 'number'},
-                {arg: 'b', type: 'number'}
-            ];
+          fn.shared = true;
+          fn.accepts = [
+              {arg: 'a', type: 'number'},
+              {arg: 'b', type: 'number'}
+          ];
 
-            fn.returns = [
-                {arg: 'a', type: 'number'},
-                {arg: 'b', type: 'number'}
-            ];
+          fn.returns = [
+              {arg: 'a', type: 'number'},
+              {arg: 'b', type: 'number'}
+          ];
 
-            json('post', '/foo/bar?a=1&b=2').set('Content-Length', 0)
-                .expect({a: 1, b: 2}, done);
+          json('post', '/foo/bar?a=1&b=2').set('Content-Length', 0)
+              .expect({a: 1, b: 2}, done);
+      });
+      describe('uncaught errors', function () {
+        it('should return 500 if an error object is thrown', function (done) {
+          remotes.shouldThrow = {
+            bar: function (fn) {
+              throw new Error('an error');
+              fn(null);
+            }
+          };
+
+          var fn = remotes.shouldThrow.bar;
+          fn.shared = true;
+
+          json('get', '/shouldThrow/bar?a=1&b=2')
+            .expect(500)
+            .expect({error: 'an error'})
+            .end(done);
         });
+        it('should return 500 if an error string is thrown', function (done) {
+          remotes.shouldThrow = {
+            bar: function (fn) {
+              throw 'an error';
+              fn(null);
+            }
+          };
+
+          var fn = remotes.shouldThrow.bar;
+          fn.shared = true;
+
+          json('get', '/shouldThrow/bar?a=1&b=2')
+            .expect(500)
+            .expect({error: 'an error'})
+            .end(done);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
/to @raymondfeng 
/cc @bajtos 

Currently strong remoting is calling back with `200` when an error is thrown. This defaults to sending 500 unless the error object specifies a `statusCode`.
