### PR TITLE
Return 404 for unknown methods of known classes + Include additional properties in error responses

### DIFF
--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -170,9 +170,19 @@ RestAdapter.errorHandler = function() {
     res.statusCode = err.statusCode || err.status || 500;
 
     debug('Error in %s %s: %s', req.method, req.url, err.stack);
-    res.send({
-      error: err.message || 'An unknown error occured'
-    });
+    var data = {
+      name: err.name,
+      status: res.statusCode,
+      message: err.message || 'An unknown error occurred'
+    };
+
+    for (var prop in err)
+      data[prop] = err[prop];
+
+    // TODO(bajtos) Remove stack info when running in production
+    data.stack = err.stack;
+
+    res.send({ error: data });
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "mocha": "~1.14.0",
     "supertest": "~0.8.1",
     "socket.io": "~0.9.16",
-    "socket.io-client": "~0.9.16"
+    "socket.io-client": "~0.9.16",
+    "chai": "~1.8.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This pull request contains two changes.

~~The first one fixes the bug [SLA-679](https://strongloop.atlassian.net/browse/SLA-679) where a request for non-existing id returned 200 + null instead of 404 + error.~~

The first improves the existing fix of the bug [SLA-679](https://strongloop.atlassian.net/browse/SLA-679). If the root application does not install correct error handler, unknown methods still return expected error response now.

The second one changes the structure of error responses in order to implement [SLA-702](https://strongloop.atlassian.net/browse/SLA-702)
- additional fields are included
- the new format is closer to what could be considered as a "standard" (see overview in SLA-702).
- it should be very easy to add details about validation errors now

/to @raymondfeng or @ritch please review.
/cc @Schoonology FYI.
