### PR TITLE
Modify RestAdapter to own the whole URL space

### DIFF
--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -89,7 +89,6 @@ RestAdapter.prototype.createHandler = function () {
   var root = express();
   var adapter = this;
   var classes = this.remotes.classes();
-  var restErrorHandler = RestAdapter.errorHandler();
 
   // Add a handler to tolerate empty json as connect's json middleware throws an error
   root.use(function(req, res, next) {
@@ -125,10 +124,6 @@ RestAdapter.prototype.createHandler = function () {
     // Do not allow other middleware to invade our URL space.
     app.use(RestAdapter.remoteMethodNotFoundHandler(sharedClass.name));
 
-    // Use our own error handler to make sure the error response has
-    // always the format expected by remoting clients.
-    app.use(restErrorHandler);
-
     // Mount the remoteClass app on all class routes.
     adapter
       .getRoutes(sharedClass)
@@ -146,6 +141,14 @@ RestAdapter.prototype.createHandler = function () {
       });
   });
 
+  // Convert requests for unknown URLs into 404.
+  // Do not allow other middleware to invade our URL space.
+  root.use(RestAdapter.urlNotFoundHandler());
+
+  // Use our own error handler to make sure the error response has
+  // always the format expected by remoting clients.
+  root.use(RestAdapter.errorHandler());
+
   return root;
 };
 
@@ -154,6 +157,15 @@ RestAdapter.remoteMethodNotFoundHandler = function(className) {
   return function restRemoteMethodNotFound(req, res, next) {
     var message = 'Shared class "' + className + '"' +
       ' has no method handling ' + req.method + ' ' + req.url;
+    var error = new Error(message);
+    error.status = error.statusCode = 404;
+    next(error);
+  };
+};
+
+RestAdapter.urlNotFoundHandler = function() {
+  return function restUrlNotFound(req, res, next) {
+    var message = 'There is no method to handle ' + req.method + ' ' + req.url;
     var error = new Error(message);
     error.status = error.statusCode = 404;
     next(error);

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -397,6 +397,12 @@ describe('strong-remoting-rest', function(){
       .expect(404, done);
   });
 
+  it('returns 404 with standard JSON body for uknown URL', function(done) {
+    json('/unknown-url')
+      .expect(404)
+      .end(expectErrorResponseContaining({status: 404}, done));
+  });
+
   it('returns correct error response body', function(done) {
     function TestError() {
       Error.captureStackTrace(this, TestError);


### PR DESCRIPTION
Add urlNotFound middleware converting all unhandled requests into a 404 error. This way to the express app created by RestAdapter.createHandler always returns consistent error responses and also prevents other parts of the application from creating a URL clash.

See strongloop/loopback#77 for more details.

/to: @ritch Please review.
