### PR TITLE
Skip the super class constructor from remoting

### DIFF
--- a/lib/shared-class.js
+++ b/lib/shared-class.js
@@ -62,6 +62,10 @@ function eachRemoteFunctionInObject(obj, f) {
   if(!obj) return;
     
   for(var key in obj) {
+    if(key === 'super_') {
+      // Skip super class
+      continue;
+    }
     var fn;
      
     try {


### PR DESCRIPTION
/to @ritch 

Before the PR, the API explorer shows an endpoint for /super_  as it takes the super class as a remotable function.
