### PR TITLE
Bump express for __proto__ fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,8 @@
   },
   "dependencies": {
     "debug": "~0.7.2",
-    "express": "~3.4.0",
+    "express": "~3.4.7",
     "eventemitter2": "~0.4.11",
-    "qs": "~0.6.5",
     "cors": "~2.1.0",
     "jayson": "~1.0.11",
     "async": "~0.2.9"


### PR DESCRIPTION
Remove extraneous qs dependency, too.

Also works with node 0.11.x
