### PR TITLE
Missing arg should return a 400 not 500

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -71,7 +71,8 @@ SharedMethod.prototype.invoke = function (scope, args, fn) {
 
   // map the given arg data in order they are expected in
   if(accepts) {
-    accepts.forEach(function (desc) {
+    for(var i = 0; i < accepts.length; i++) {
+      var desc = accepts[i];
       var name = desc.name || desc.arg;
       var uarg = args[name];
       var actualType = SharedMethod.getType(uarg);
@@ -80,7 +81,9 @@ SharedMethod.prototype.invoke = function (scope, args, fn) {
       // arg was not provided
       if(actualType === 'undefined') {
         if(desc.required) {
-          throw new Error(name + ' is a required arg');
+          var err = new Error(name + ' is a required arg');
+          err.statusCode = 400;
+          return fn(err);
         } else {
           // Add the argument even if it's undefined to stick with the accepts
           formattedArgs.push(undefined);
@@ -106,7 +109,7 @@ SharedMethod.prototype.invoke = function (scope, args, fn) {
 
       // Add the argument even if it's undefined to stick with the accepts
       formattedArgs.push(uarg);
-    });
+    }
   }
 
   // define the callback

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -329,6 +329,22 @@ describe('strong-remoting-rest', function(){
         .expect(500)
         .end(expectErrorResponseContaining({message: 'test-error'}, done));
     });
+
+    it('should return 400 when a required arg is missing', function (done) {
+      var method = givenSharedPrototypeMethod(
+        function(a, cb) {
+          cb();
+        },
+        {
+          accepts: [
+            { arg: 'a', type: 'number', required: true }
+          ]
+        }
+      );
+
+      json(method.url)
+        .expect(400, done);
+    });
   });
 
   describe('call of prototype method', function(){


### PR DESCRIPTION
/to @bajtos 
/related https://github.com/strongloop/loopback/issues/117#issuecomment-31399675

Should this be released as `1.1.6` or `1.2.0`?
