### PR TITLE
Improve remoting metadata - Add ctor.http to SharedClass

### DIFF
--- a/ext/swagger.js
+++ b/ext/swagger.js
@@ -36,7 +36,7 @@ function Swagger(remotes, options, models) {
 
   classes.forEach(function (item) {
     resourceDoc.apis.push({
-      path: '/' + name + '/' + item.name,
+      path: '/' + name + item.http.path,
       description: item.ctor.sharedCtor && item.ctor.sharedCtor.description
     });
 
@@ -50,6 +50,7 @@ function Swagger(remotes, options, models) {
 
     helper.method(api, {
       path: item.name,
+      http: { path: item.http.path },
       returns: { type: 'object', root: true }
     });
     function api(callback) {

--- a/lib/shared-class.js
+++ b/lib/shared-class.js
@@ -32,6 +32,8 @@ function SharedClass(name, ctor) {
     assert(ctor.sharedCtor, 'must define a sharedCtor');
     this.sharedCtor = new SharedMethod(ctor.sharedCtor, 'sharedCtor');
   }
+
+  this.http = util._extend({ path: '/' + this.name }, ctor.http);
   
   assert(this.name, 'must include a remoteNamespace when creating a SharedClass');
 }

--- a/test/shared-class.test.js
+++ b/test/shared-class.test.js
@@ -1,0 +1,22 @@
+var extend = require('util')._extend;
+var expect = require('chai').expect;
+var SharedClass = require('../lib/shared-class');
+var factory = require('./helpers/shared-objects-factory.js');
+
+describe('SharedClass', function() {
+  var SomeClass;
+  beforeEach(function() { SomeClass = factory.createSharedClass(); });
+
+  describe('constructor', function() {
+    it('fills http.path from ctor.http', function() {
+      SomeClass.http = { path: '/foo' };
+      var sc = new SharedClass('some', SomeClass);
+      expect(sc.http.path).to.equal('/foo');
+    });
+
+    it('fills http.path using the name', function() {
+      var sc = new SharedClass('some', SomeClass);
+      expect(sc.http.path).to.equal('/some');
+    });
+  });
+});


### PR DESCRIPTION
The SharedClass has the `http` property always set now. If the
ctor does not provide `http.path`, a default value of `'/' + name` is
used. This way we can decouple the REST (HTTP) routing from the model
name and make the REST path accessible from any external code.

The second part of the commit modifies ext/swagger to use this new
property.

/to: @ritch please review
/cc: @raymondfeng @Schoonology 

This is the first pull requests in the upcoming series of changes that will make it super easy to generate client code from metadata provided by `RemoteObjects` via `classes()`.
