### PR TITLE
Clean up RestAdapter, add RestClass and RestMethod

### DIFF
--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -4,6 +4,9 @@
 
 module.exports = RestAdapter;
 
+RestAdapter.RestClass = RestClass;
+RestAdapter.RestMethod = RestMethod;
+
 /*!
  * Module dependencies.
  */
@@ -52,7 +55,8 @@ RestAdapter.createRestAdapter = function (remotes) {
  * Get the path for the given method.
  */
 
-RestAdapter.prototype.getRoutes = function (obj) {
+RestAdapter.prototype.getRoutes = getRoutes;
+function getRoutes(obj) {
   var fn = (obj.fn || obj.ctor);
   var routes = fn && fn.http;
 
@@ -88,7 +92,7 @@ RestAdapter.prototype.getRoutes = function (obj) {
 RestAdapter.prototype.createHandler = function () {
   var root = express();
   var adapter = this;
-  var classes = this.remotes.classes();
+  var classes = this.getClasses();
 
   // Add a handler to tolerate empty json as connect's json middleware throws an error
   root.use(function(req, res, next) {
@@ -106,28 +110,32 @@ RestAdapter.prototype.createHandler = function () {
   root.use(express.json({strict: false}));
   root.use(cors());
 
-  classes.forEach(function (sharedClass) {
+  classes.forEach(function (restClass) {
     var app = express();
+    var className = restClass.sharedClass.name;
+
+    debug('registering REST handler for class %j', className);
 
     // Register handlers for all shared methods of this class sharedClass
-    sharedClass
-      .methods()
-      .forEach(function(sharedMethod) {
-        adapter
-          .getRoutes(sharedMethod)
-          .forEach(function(route) {
-            adapter._registerMethodRouteHandlers(app, sharedMethod, route);
-          });
+    restClass
+      .methods
+      .forEach(function(restMethod) {
+        var sharedMethod = restMethod.sharedMethod;
+        debug('    method %s', sharedMethod.stringName);
+        restMethod.routes.forEach(function(route) {
+          adapter._registerMethodRouteHandlers(app, sharedMethod, route);
+        });
       });
 
     // Convert requests for unknown methods of this sharedClass into 404.
     // Do not allow other middleware to invade our URL space.
-    app.use(RestAdapter.remoteMethodNotFoundHandler(sharedClass.name));
+    app.use(RestAdapter.remoteMethodNotFoundHandler(className));
 
     // Mount the remoteClass app on all class routes.
-    adapter
-      .getRoutes(sharedClass)
+    restClass
+      .routes
       .forEach(function (route) {
+        debug('    at %s', route.path);
         root.use(route.path, app);
       });
 
@@ -199,52 +207,38 @@ RestAdapter.errorHandler = function() {
 };
 
 RestAdapter.prototype._registerMethodRouteHandlers = function(app,
-                                                              method,
+                                                              sharedMethod,
                                                               route) {
-  if (method.isStatic) {
-    app[route.verb](
-      route.path,
-      this._createStaticMethodHandler(method)
-    );
-    return;
-  }
+  var handler = sharedMethod.isStatic ?
+    this._createStaticMethodHandler(sharedMethod) :
+    this._createPrototypeMethodHandler(sharedMethod);
 
-  var self = this;
-  this
-    .getRoutes(method.sharedCtor)
-    .forEach(function(sharedCtorRoute) {
-      var methodPath = route.path === '/' ? '' : route.path;
-      var ctorPath = sharedCtorRoute.path === '/' ? '' : sharedCtorRoute.path;
-      var fullPath = (ctorPath + methodPath) || '/';
-      app[route.verb](
-        fullPath,
-        self._createPrototypeMethodHandler(method)
-      );
-    });
+  debug('        %s %s %s', route.verb, route.path, handler.name);
+  app[route.verb](route.path, handler);
 };
 
-RestAdapter.prototype._createStaticMethodHandler = function(method) {
+RestAdapter.prototype._createStaticMethodHandler = function(sharedMethod) {
   var self = this;
   var Context = this.Context;
 
   return function restStaticMethodHandler(req, res, next) {
-    var ctx = new Context(req, res, method);
-    self._invokeMethod(ctx, method, next);
+    var ctx = new Context(req, res, sharedMethod);
+    self._invokeMethod(ctx, sharedMethod, next);
   };
 };
 
-RestAdapter.prototype._createPrototypeMethodHandler = function(method) {
+RestAdapter.prototype._createPrototypeMethodHandler = function(sharedMethod) {
   var self = this;
   var Context = this.Context;
 
   return function restPrototypeMethodHandler(req, res, next) {
-    var ctx = new Context(req, res, method);
+    var ctx = new Context(req, res, sharedMethod);
 
     // invoke the shared constructor to get an instance
-    ctx.invoke(method, method.sharedCtor, function(err, inst) {
+    ctx.invoke(sharedMethod, sharedMethod.sharedCtor, function(err, inst) {
       if (err) return next(err);
       ctx.instance = inst;
-      self._invokeMethod(ctx, method, next);
+      self._invokeMethod(ctx, sharedMethod, next);
     }, true);
   };
 };
@@ -349,6 +343,12 @@ RestAdapter.prototype.allRoutes = function () {
   }
 }
 
+RestAdapter.prototype.getClasses = function() {
+  return this.remotes.classes().map(function(c) {
+    return new RestClass(c);
+  });
+};
+
 // path part routes should
 // not override explicit routes
 function sortRoutes(a, b) {
@@ -357,4 +357,109 @@ function sortRoutes(a, b) {
   } else {
     return -1;
   }
+}
+
+function RestClass(sharedClass) {
+  nonEnumerableConstPropery(this, 'sharedClass', sharedClass);
+
+  this.name = sharedClass.name;
+  this.routes = getRoutes(sharedClass);
+
+  this.ctor = sharedClass.sharedCtor &&
+    new RestMethod(this, sharedClass.sharedCtor);
+
+  this.methods = sharedClass.methods()
+    .filter(function(sm) { return !sm.isSharedCtor; })
+    .map(function(sm) {
+      return new RestMethod(this, sm);
+    }.bind(this));
+}
+
+RestClass.prototype.getPath = function() {
+  return this.routes[0].path;
+};
+
+function RestMethod(restClass, sharedMethod) {
+  nonEnumerableConstPropery(this, 'restClass', restClass);
+  nonEnumerableConstPropery(this, 'sharedMethod', sharedMethod);
+
+  // The full name is ClassName.methodName or ClassName.prototype.methodName
+  this.fullName = sharedMethod.stringName;
+  this.name = this.fullName.split('.').slice(1).join('.');
+
+  this.accepts = sharedMethod.accepts;
+  this.returns = sharedMethod.returns;
+  this.description = sharedMethod.description;
+
+  var methodRoutes = getRoutes(sharedMethod);
+  if (sharedMethod.isStatic || !restClass.ctor) {
+    this.routes = methodRoutes;
+  } else {
+    var routes = this.routes = [];
+    methodRoutes.forEach(function(route) {
+      restClass.ctor.routes.forEach(function(ctorRoute) {
+        var fullRoute = util._extend({}, route);
+        fullRoute.path = joinPaths(ctorRoute.path, route.path);
+        routes.push(fullRoute);
+      });
+    });
+  }
+}
+
+RestMethod.prototype.isReturningArray = function() {
+  return this.returns.length == 1 &&
+    this.returns[0].root &&
+    getTypeString(this.returns[0].type) === 'array' || false;
+};
+
+RestMethod.prototype.acceptsSingleBodyArgument = function() {
+  if (this.accepts.length != 1) return false;
+  var accepts = this.accepts[0];
+
+  return accepts.http &&
+    accepts.http.source == 'body' &&
+    getTypeString(accepts.type) == 'object' || false;
+};
+
+RestMethod.prototype.getHttpMethod = function() {
+  var verb = this.routes[0].verb;
+  if (verb == 'all') return 'POST';
+  if (verb == 'del') return 'DELETE';
+  return verb.toUpperCase();
+};
+
+RestMethod.prototype.getPath = function() {
+  return this.routes[0].path;
+};
+
+RestMethod.prototype.getFullPath = function() {
+  return joinPaths(this.restClass.getPath(), this.getPath());
+};
+
+function getTypeString(ctorOrName) {
+  if (typeof ctorOrName === 'function')
+    ctorOrName = ctorOrName.name;
+  return ctorOrName.toLowerCase();
+}
+
+function nonEnumerableConstPropery(object, name, value) {
+  Object.defineProperty(object, name, {
+    value: value,
+    enumerable: false,
+    writable: false,
+    configurable: false
+  });
+}
+
+function joinPaths(left, right) {
+  if (!left) return right;
+  if (!right || right == '/') return left;
+
+  var glue = left[left.length-1] + right[0];
+  if (glue == '//')
+    return left + right.slice(1);
+  else if (glue[0] == '/' || glue[1] == '/')
+    return left + right;
+  else
+    return left + '/' + right;
 }

--- a/test/helpers/shared-objects-factory.js
+++ b/test/helpers/shared-objects-factory.js
@@ -21,10 +21,11 @@
 
 var extend = require('util')._extend;
 
-exports.createSharedClass =  function createSharedClass() {
+exports.createSharedClass =  function createSharedClass(config) {
   var SharedClass = function(id) {
     this.id = id;
   };
+  extend(SharedClass, config);
 
   SharedClass.shared = true;
 

--- a/test/rest-adapter.test.js
+++ b/test/rest-adapter.test.js
@@ -1,0 +1,212 @@
+var extend = require('util')._extend;
+var inherits = require('util').inherits;
+var RemoteObjects = require('../');
+var RestAdapter = require('../lib/rest-adapter');
+var SharedClass = require('../lib/shared-class');
+var SharedMethod = require('../lib/shared-method');
+var expect = require('chai').expect;
+var factory = require('./helpers/shared-objects-factory.js');
+
+describe('RestAdapter', function() {
+  var remotes;
+
+  beforeEach(function() {
+    remotes = RemoteObjects.create();
+  });
+
+
+  describe('getClasses()', function() {
+    it('fills `name`', function() {
+      remotes.exports.testClass = factory.createSharedClass();
+      var classes = getRestClasses();
+      expect(classes[0]).to.have.property('name', 'testClass');
+    });
+
+    it('fills `routes`', function() {
+      remotes.exports.testClass = factory.createSharedClass();
+      remotes.exports.testClass.http = { path: '/test-class', verb: 'any' };
+
+      var classes = getRestClasses();
+
+      expect(classes[0]).to.have.property('routes')
+        .eql([{ path: '/test-class', verb: 'any' }]);
+    });
+
+    it('fills `ctor`', function() {
+      var testClass = remotes.exports.testClass = factory.createSharedClass();
+      testClass.sharedCtor.http = { path: '/shared-ctor', verb: 'all' };
+
+      var classes = getRestClasses();
+
+      expect(classes[0].ctor).to.have.property('routes')
+        .eql([{ path: '/shared-ctor', verb: 'all' }]);
+    });
+
+    it('fills static methods', function() {
+      var testClass = remotes.exports.testClass = factory.createSharedClass();
+      testClass.staticMethod = extend(someFunc, { shared: true });
+
+      var methods = getRestClasses()[0].methods;
+
+      expect(methods).to.have.length(1);
+      expect(methods[0]).to.have.property('name', 'staticMethod');
+      expect(methods[0]).to.have.property('fullName', 'testClass.staticMethod');
+      expect(methods[0])
+        .to.have.deep.property('routes[0].path', '/staticMethod');
+    });
+
+    it('fills prototype methods', function() {
+      var testClass = remotes.exports.testClass = factory.createSharedClass();
+      testClass.prototype.instanceMethod = extend(someFunc, { shared: true });
+
+      var methods = getRestClasses()[0].methods;
+
+      expect(methods).to.have.length(1);
+      expect(methods[0])
+        .to.have.property('fullName', 'testClass.prototype.instanceMethod');
+      expect(methods[0])
+        // Note: the `/id:` part is coming from testClass.sharedCtor
+        .to.have.deep.property('routes[0].path', '/:id/instanceMethod');
+    });
+
+    function getRestClasses() {
+      return new RestAdapter(remotes).getClasses();
+    }
+  });
+
+  describe('RestClass', function() {
+    describe('getPath', function() {
+      it('returns the path of the first route', function() {
+        var restClass = givenRestClass({ http: [
+          { path: '/a-path' },
+          { path: '/another-path' }
+        ]});
+        expect(restClass.getPath()).to.equal('/a-path');
+      });
+    });
+
+    function givenRestClass(config) {
+      var ctor = factory.createSharedClass(config);
+      remotes.testClass = ctor;
+      var sharedClass = new SharedClass('testClass', ctor);
+      return new RestAdapter.RestClass(sharedClass);
+    }
+  });
+
+  describe('RestMethod', function() {
+    var anArg = { arg: 'an-arg-name', type: String };
+
+    it('has `accepts`', function() {
+      var method = givenRestStaticMethod({ accepts: anArg });
+      expect(method.accepts).to.eql([anArg]);
+    });
+
+    it('has `returns`', function() {
+      var method = givenRestStaticMethod({ returns: anArg });
+      expect(method.returns).to.eql([anArg]);
+    });
+
+    it('has `description`', function() {
+      var method = givenRestStaticMethod({ description: 'a-desc' });
+      expect(method.description).to.equal('a-desc');
+    });
+
+    describe('isReturningArray()', function() {
+      it('returns true when there is single root Array arg', function() {
+        var method = givenRestStaticMethod({
+          returns: { root: true, type: Array }
+        });
+        expect(method.isReturningArray()).to.equal(true);
+      });
+
+      it('returns true when there is single root "array" arg', function() {
+        var method = givenRestStaticMethod({
+          returns: { root: true, type: Array }
+        });
+        expect(method.isReturningArray()).to.equal(true);
+      });
+
+      it('returns false otherwise', function() {
+        var method = givenRestStaticMethod({
+          returns: { arg: 'result', type: Array }
+        });
+        expect(method.isReturningArray()).to.equal(false);
+      });
+    });
+
+    describe('acceptsSingleBodyArgument()', function() {
+      it('returns true when the arg is a single Object from body', function() {
+        var method = givenRestStaticMethod({
+          accepts: {
+            arg: 'data',
+            type: Object,
+            http: { source: 'body' }
+          }
+        });
+        expect(method.acceptsSingleBodyArgument()).to.equal(true);
+      });
+
+      it('returns false otherwise', function() {
+        var method = givenRestStaticMethod({
+          accepts: { arg: 'data', type: Object }
+        });
+        expect(method.acceptsSingleBodyArgument()).to.equal(false);
+      });
+    });
+
+    describe('getHttpMethod', function() {
+      it('returns POST for `all`', function() {
+        var method = givenRestStaticMethod({ http: { verb: 'all'} });
+        expect(method.getHttpMethod()).to.equal('POST');
+      });
+
+      it('returns DELETE for `del`', function() {
+        var method = givenRestStaticMethod({ http: { verb: 'del'} });
+        expect(method.getHttpMethod()).to.equal('DELETE');
+      });
+
+      it('returns upper-case value otherwise', function() {
+        var method = givenRestStaticMethod({ http: { verb: 'get'} });
+        expect(method.getHttpMethod()).to.equal('GET');
+      });
+    });
+
+    describe('getPath', function() {
+      it('returns the path of the first route', function() {
+        var method = givenRestStaticMethod({ http: [
+          { path: '/a-path' },
+          { path: '/another-path' }
+        ]});
+        expect(method.getPath()).to.equal('/a-path');
+      });
+    });
+
+    describe('getFullPath', function() {
+      it('returns class path + method path', function() {
+        var method = givenRestStaticMethod(
+          { http: { path: '/a-method' } },
+          { http: { path: '/a-class' } }
+        );
+
+        expect(method.getFullPath()).to.equal('/a-class/a-method');
+      });
+    });
+
+    function givenRestStaticMethod(methodConfig, classConfig) {
+      var name = 'testMethod';
+      methodConfig = extend({ shared: true }, methodConfig);
+      classConfig = extend({ shared: true}, classConfig);
+      remotes.testClass = extend({}, classConfig);
+      var fn = remotes.testClass[name] = extend(function(){}, methodConfig);
+
+      var sharedClass = new SharedClass('testClass', remotes.testClass);
+      var restClass = new RestAdapter.RestClass(sharedClass);
+
+      var sharedMethod = new SharedMethod(fn, name, sharedClass, true);
+      return new RestAdapter.RestMethod(restClass, sharedMethod);
+    }
+  });
+});
+
+function someFunc() {
+}

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -522,6 +522,16 @@ describe('strong-remoting-rest', function(){
         .expect({ n: 'sum:3' }, done);
     });
 
+    it('should support methods on `/` path', function(done) {
+      var method = givenSharedPrototypeMethod({
+        http: { path: '/', verb: 'get'}
+      });
+
+      json('get', method.getClassUrlForId(0))
+        .expect(204) // 204 No Content
+        .end(done);
+    });
+
     it('should respond with 204 if returns is not defined', function(done) {
       var method = givenSharedPrototypeMethod(
         function(cb) { cb(null, 'value-to-ignore'); }
@@ -650,6 +660,11 @@ describe('strong-remoting-rest', function(){
   }
 
   function givenSharedPrototypeMethod(fn, config) {
+    if (typeof fn === 'object' && config === undefined) {
+      config = fn;
+      fn = undefined;
+    }
+
     fn = fn || function(cb) { cb(); };
     remotes.testClass = factory.createSharedClass();
     remotes.testClass.prototype.testMethod = fn;


### PR DESCRIPTION
Simplify the code building up the REST handler. Code that can be reused
is moved to two new classes - RestAdapter and RestMethod.

These two new classes should contain all information needed to generate
front-end code (Angular $resource factory, Swagger descriptors, etc.).
