### PR TITLE
Fix the handling of accept header for jsonp

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -248,9 +248,6 @@ HttpContext.prototype.done = function () {
       case 'json':
       case 'application/javascript':
       case 'text/javascript':
-        if(data === null) {
-          data = 'null';
-        }
         res.jsonp(data);
       break;
       default:

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -523,6 +523,26 @@ describe('strong-remoting-rest', function(){
         .expect('typeof boo === \'function\' && boo(1);', done);
     });
 
+    it('should allow jsonp requests with null response', function (done) {
+      var method = givenSharedStaticMethod(
+        function bar(a, cb) {
+          cb(null, null);
+        },
+        {
+          accepts: [
+            { arg: 'a', type: 'number', http: {source: 'path'} }
+          ],
+          returns: { arg: 'n', type: 'number', root: true},
+          http: { path: '/:a' }
+        }
+      );
+
+      request(app)['get'](method.classUrl + '/1?callback=boo')
+        .set('Accept', 'application/javascript')
+        .expect('Content-Type', /javascript/)
+        .expect('typeof boo === \'function\' && boo(null);', done);
+    });
+
     it('should allow arguments in the query', function(done) {
       var method = givenSharedPrototypeMethod(
         function bar(a, b, cb) {


### PR DESCRIPTION
/to @ritch 

jQuery AJAX sets the Accept header to be 'application/javascript' for jsonp request.
