### PR TITLE
Handle undefined argument type

### DIFF
--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -443,7 +443,13 @@ RestMethod.prototype.getFullPath = function() {
 function getTypeString(ctorOrName) {
   if (typeof ctorOrName === 'function')
     ctorOrName = ctorOrName.name;
-  return ctorOrName.toLowerCase();
+  if (typeof ctorOrName === 'string') {
+    return ctorOrName.toLowerCase();
+  } else {
+    debug('WARNING: unkown ctorOrName of type %s: %j',
+      typeof ctorOrName, ctorOrName);
+    return typeof undefined;
+  }
 }
 
 function nonEnumerableConstPropery(object, name, value) {

--- a/test/rest-adapter.test.js
+++ b/test/rest-adapter.test.js
@@ -132,6 +132,13 @@ describe('RestAdapter', function() {
         });
         expect(method.isReturningArray()).to.equal(false);
       });
+
+      it('handles invalid type', function() {
+        var method = givenRestStaticMethod({
+          returns: { root: true }
+        });
+        expect(method.isReturningArray()).to.equal(false);
+      });
     });
 
     describe('acceptsSingleBodyArgument()', function() {


### PR DESCRIPTION
Fix getTypeString in rest-adapter to handle the situation where
the type is not specified or not a function/string.

Close strongloop/loopback-angular#21.

/to @raymondfeng or @ritch  please review
/cc @Cadrach
