### PR TITLE
user confirmation header  error

### DIFF
--- a/example/rest-models/app.js
+++ b/example/rest-models/app.js
@@ -9,6 +9,9 @@ var express = require('express');
 var app = express();
 var remotes = require('./remotes');
 
+// Disable X-Powered-By header
+app.disable('x-powered-by');
+
 app.use(remotes.handler('rest'));
 app.use(express.static('public'));
 

--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -246,7 +246,6 @@ HttpContext.prototype.done = function () {
   // the requested content type
   var data = this.result;
   var res = this.res;
-  res.removeHeader('X-Powered-By');
   var accepts = this.req.accepts(SUPPORTED_TYPES);
   var dataExists = typeof data !== 'undefined';
 

--- a/lib/jsonrpc-adapter.js
+++ b/lib/jsonrpc-adapter.js
@@ -94,6 +94,9 @@ JsonRpcAdapter.prototype.createHandler = function () {
   var root = express();
   var classes = this.remotes.classes();
 
+  // Disable X-Powered-By header
+  root.disable('x-powered-by');
+
   // Add a handler to tolerate empty json as connect's json middleware throws an error
   root.use(function (req, res, next) {
     if (req.is('application/json')) {

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -126,6 +126,9 @@ RestAdapter.prototype.createHandler = function () {
   var adapter = this;
   var classes = this.getClasses();
 
+  // Disable X-Powered-By header
+  root.disable('x-powered-by');
+
   // Add a handler to tolerate empty json as connect's json middleware throws an error
   root.use(function(req, res, next) {
     if(req.is('application/json')) {
@@ -149,6 +152,10 @@ RestAdapter.prototype.createHandler = function () {
   classes.forEach(function (restClass) {
     var app = express();
     var className = restClass.sharedClass.name;
+
+    // Disable X-Powered-By header
+    app.disable('x-powered-by');
+
 
     debug('registering REST handler for class %j', className);
 

--- a/test/jsonrpc.test.js
+++ b/test/jsonrpc.test.js
@@ -14,6 +14,9 @@ describe('strong-remoting-jsonrpc', function () {
     objects = RemoteObjects.create({json: {limit: '1kb'}});
     remotes = objects.exports;
     app = express();
+
+    // Disable X-Powered-By header
+    app.disable('x-powered-by');
   });
 
   function jsonrpc(url, method, parameters) {

--- a/test/rest.browser.test.js
+++ b/test/rest.browser.test.js
@@ -15,6 +15,10 @@ describe('strong-remoting-rest', function(){
   
   before(function(done) {
     app = express();
+
+    // Disable X-Powered-By header
+    app.disable('x-powered-by');
+
     app.use(function (req, res, next) {
       // create the handler for each request
       objects.handler(adapterName).apply(objects, arguments);

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -15,6 +15,10 @@ describe('strong-remoting-rest', function(){
   
   before(function(done) {
     app = express();
+
+    // Disable X-Powered-By header
+    app.disable('x-powered-by');
+
     app.use(function (req, res, next) {
       // create the handler for each request
       objects.handler(adapterName).apply(objects, arguments);

--- a/test/streams.js
+++ b/test/streams.js
@@ -6,16 +6,19 @@ var fs = require('fs');
 describe('strong-remoting', function () {
   var app, remotes, objects;
 
-  beforeEach(function(){
+  beforeEach(function () {
     objects = RemoteObjects.create();
     remotes = objects.exports;
     app = express();
+
+    // Disable X-Powered-By header
+    app.disable('x-powered-by');
 
     app.use(function (req, res, next) {
       objects.handler('rest').apply(objects, arguments);
     });
   });
-  
+
   function json(method, url) {
     return request(app)[method](url)
       .set('Accept', 'application/json')
@@ -27,7 +30,9 @@ describe('strong-remoting', function () {
   it('should stream the file output', function (done) {
     remotes.fs = fs;
     fs.createReadStream.shared = true;
-    fs.createReadStream.accepts = [{arg: 'path', type: 'string'}];
+    fs.createReadStream.accepts = [
+      {arg: 'path', type: 'string'}
+    ];
     fs.createReadStream.returns = {arg: 'res', type: 'stream'};
     fs.createReadStream.http = {
       verb: 'get',

--- a/test/swagger.test.js
+++ b/test/swagger.test.js
@@ -30,33 +30,33 @@ var swagger = require('../ext/swagger.js');
 var request = require('supertest');
 var expect = require('chai').expect;
 
-describe('swagger definition', function() {
+describe('swagger definition', function () {
   var objects;
   var remotes;
 
   // setup
-  beforeEach(function(){
+  beforeEach(function () {
     objects = RemoteObjects.create();
     remotes = objects.exports;
   });
 
-  describe('basePath', function() {
-    it('is "http://{host}/" by default', function(done) {
+  describe('basePath', function () {
+    it('is "http://{host}/" by default', function (done) {
       swagger(objects);
 
       var getReq = getSwaggerResources();
-      getReq.end(function(err, res) {
-          if (err) return done(err);
-          expect(res.body.basePath).to.equal(url.resolve(getReq.url, '/'));
-          done();
-        });
+      getReq.end(function (err, res) {
+        if (err) return done(err);
+        expect(res.body.basePath).to.equal(url.resolve(getReq.url, '/'));
+        done();
+      });
     });
 
-    it('is "http://{host}/{basePath}" when basePath is a path', function(done){
+    it('is "http://{host}/{basePath}" when basePath is a path', function (done) {
       swagger(objects, { basePath: '/api-root'});
 
       var getReq = getSwaggerResources();
-      getReq.end(function(err, res) {
+      getReq.end(function (err, res) {
         if (err) return done(err);
         var apiRoot = url.resolve(getReq.url, '/api-root');
         expect(res.body.basePath).to.equal(apiRoot);
@@ -64,13 +64,13 @@ describe('swagger definition', function() {
       });
     });
 
-    it('is custom URL when basePath is a http(s) URL', function(done) {
+    it('is custom URL when basePath is a http(s) URL', function (done) {
       var apiUrl = 'http://custom-api-url/';
 
       swagger(objects, { basePath: apiUrl });
 
       var getReq = getSwaggerResources();
-      getReq.end(function(err, res) {
+      getReq.end(function (err, res) {
         if (err) return done(err);
         expect(res.body.basePath).to.equal(apiUrl);
         done();
@@ -92,6 +92,10 @@ describe('swagger definition', function() {
     restPath = restPath || '/';
 
     var app = express();
+
+    // Disable X-Powered-By header
+    app.disable('x-powered-by');
+
     app.use(restPath, function (req, res, next) {
       // create the handler for each request
       objects.handler('rest').apply(objects, arguments);


### PR DESCRIPTION
Prevent the X-Powered-By header from being set, instead of removing it, which was causing the application to throw an exception when an API User was confirmed
