### PR TITLE
Bump cors module version to ~2.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "debug": "~0.7.2",
     "express": "~3.4.7",
     "eventemitter2": "~0.4.11",
-    "cors": "~2.1.0",
+    "cors": "~2.3.0",
     "jayson": "~1.0.11",
     "async": "~0.2.9",
     "traverse": "~0.6.6",


### PR DESCRIPTION
Hi,

there's a bug fix (https://github.com/troygoode/node-cors/pull/18)  available on the new version of the Cors module. This PR bumps the version only. The tests are still green =)

thanks
