### PR TITLE
Exclude body-parser from the browser bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "browser": {
     "express": false,
+    "body-parser": false,
     "request": "browser-request"
   },
   "license": {


### PR DESCRIPTION
When the express dependency was upgraded from 3.x to 4.x (see #66),
adapters were changed to require `body-parser` directly instead
of using `express.json` and `express.urlencoded`.

The module `body-parser` does not work in browser, as it is loading
a list of mime types from a file.

This commit adds a package.json rule to exlude `body-parser` from
the browser bundle.

/to @ritch @raymondfeng please review
