### PR TITLE
Swagger: Don't show derived parameters in param lists.

### DIFF
--- a/ext/swagger.js
+++ b/ext/swagger.js
@@ -78,6 +78,11 @@ function Swagger(remotes, options, models) {
       route.accepts = (route.accepts || []).concat(classDef.sharedCtor.accepts);
     }
 
+    // Don't show derived params.
+    route.accepts = route.accepts.filter(function(accept){
+      return !accept.http;
+    });
+
     debug('route %j', route);
     doc.apis.push(routeToAPI(route));
   });


### PR DESCRIPTION
When using the `http` configuration for a param to a remote method, the param is still shown in the API explorer.

For example, I might use a derived param to get the current userID:

``` javascript
accepts.push({arg: 'userId', type: 'number', http: function(ctx) {
  return ctx.req.accessToken && ctx.req.accessToken.userId;
}});
```

That way, when the callback to `loopback.remoteMethod()` is called, it has the current userId - a workaround since we are not passed the `ctx` object in that callback.

These sorts of params should not show up in the API explorer as they are not accepted by the user, they are derived from the `ctx`.
