### PR TITLE
Skip properties that are shared model classes

### DIFF
--- a/lib/shared-class.js
+++ b/lib/shared-class.js
@@ -176,8 +176,13 @@ function eachRemoteFunctionInObject(obj, f) {
       fn = obj[key];
     } catch(e) {
     }
-    
-    if(typeof fn === 'function' && fn.shared) {
+
+    // HACK: [rfeng] Do not expose model constructors
+    // We have the following usage to set other model classes as properties
+    // User.email = Email;
+    // User.accessToken = AccessToken;
+    // Both Email and AccessToken can have shared flag set to true
+    if(typeof fn === 'function' && fn.shared && !fn.modelName) {
       f(fn, key);
     }
   }

--- a/test/shared-class.test.js
+++ b/test/shared-class.test.js
@@ -77,6 +77,21 @@ describe('SharedClass', function() {
         return fn;
       }
     });
+    it('should skip properties that are model classes', function() {
+      var sc = new SharedClass('some', SomeClass);
+      function MockModel1() {};
+      MockModel1.modelName = 'M1';
+      MockModel1.shared = true;
+      SomeClass.staticMethod = MockModel1;
+
+      function MockModel2() {};
+      MockModel2.modelName = 'M2';
+      MockModel2.shared = true;
+      SomeClass.prototype.instanceMethod = MockModel2;
+      var fns = sc.methods().map(function(m) {return m.fn});
+      expect(fns).to.not.contain(SomeClass.staticMethod);
+      expect(fns).to.not.contain(SomeClass.prototype.instanceMethod);
+    });
   });
 
   describe('sharedClass.defineMethod(name, options)', function() {


### PR DESCRIPTION
/to @bajtos 

The PR removes the invalid routes for a model that has properties of shared model classes. 

``` js
UserModel.email = require('./email');
UserModel.accessToken = require('./access-token');
```

The code above caused invalid routes such as POST /api/users/email, POST /api/users/accessToken to show up in the api explorer before this PR.
