### PR TITLE
[1.x] rest: use `app.delete` instead of `app.del`

### DIFF
--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -250,8 +250,9 @@ RestAdapter.prototype._registerMethodRouteHandlers = function(app,
     this._createStaticMethodHandler(sharedMethod) :
     this._createPrototypeMethodHandler(sharedMethod);
 
-  debug('        %s %s %s', route.verb, route.path, handler.name);
-  app[route.verb](route.path, handler);
+  var verb = route.verb === 'del' ? 'delete' : route.verb;
+  debug('        %s %s %s', verb, route.path, handler.name);
+  app[verb](route.path, handler);
 };
 
 RestAdapter.prototype._createStaticMethodHandler = function(sharedMethod) {


### PR DESCRIPTION
`app.del` was deprecated in express.

```
express deprecated app.del: Use app.delete instead strong-remoting/lib/rest-adapter.js:254:18
```

/to @ritch please review
