### PR TITLE
rest: fix RestMethod.isReturningArray

### DIFF
--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -528,6 +528,8 @@ function getTypeString(ctorOrName) {
     ctorOrName = ctorOrName.name;
   if (typeof ctorOrName === 'string') {
     return ctorOrName.toLowerCase();
+  } else if (Array.isArray(ctorOrName)) {
+    return 'array';
   } else {
     debug('WARNING: unkown ctorOrName of type %s: %j',
       typeof ctorOrName, ctorOrName);

--- a/test/rest-adapter.test.js
+++ b/test/rest-adapter.test.js
@@ -125,6 +125,13 @@ describe('RestAdapter', function() {
         expect(method.isReturningArray()).to.equal(true);
       });
 
+      it('returns true when there is single root [Model] arg', function() {
+        var method = givenRestStaticMethod({
+          returns: { root: true, type: ['string'] }
+        });
+        expect(method.isReturningArray()).to.equal(true);
+      });
+
       it('returns false otherwise', function() {
         var method = givenRestStaticMethod({
           returns: { arg: 'result', type: Array }


### PR DESCRIPTION
Handle correctly the LDL type `[Item]`.

/to @ritch or @raymondfeng 

Close https://github.com/strongloop/loopback/issues/400
