### PR TITLE
Add sharedClass.disableMethod()

### DIFF
--- a/lib/shared-class.js
+++ b/lib/shared-class.js
@@ -33,6 +33,7 @@ function SharedClass(name, ctor, options) {
   this.ctor = ctor;
   this._methods = [];
   this._resolvers = [];
+  this._disabledMethods = {};
   var http = ctor && ctor.http;
   var normalize = options.normalizeHttpPath;
   
@@ -123,9 +124,19 @@ SharedClass.prototype.methods = function () {
   
   methods = methods.concat(this._methods);
 
-  return methods.filter(function(sharedMethod) {
-    return sharedMethod.shared === true;
-  });
+  return methods.filter(sc.isMethodEnabled.bind(sc));
+}
+
+SharedClass.prototype.isMethodEnabled = function(sharedMethod) {
+  if(!sharedMethod.shared) return false;
+  
+  var key = this.getKeyFromMethodNameAndTarget(sharedMethod.name, sharedMethod.isStatic);
+
+  if(this._disabledMethods.hasOwnProperty(key)) {
+    return false;
+  }
+
+  return true;
 }
 
 /**
@@ -182,6 +193,30 @@ SharedClass.prototype.resolve = function(resolver) {
 SharedClass.prototype.find = function(fn, isStatic) {
   var methods = this.methods();
   return find(methods, fn, isStatic);
+}
+
+/**
+ * Disable a sharedMethod with the given name or function object.
+ *
+ * @param {String} fn The function or method name
+ * @param {Boolean} isStatic Disable a static or prototype method
+ */
+
+SharedClass.prototype.disableMethod = function(fn, isStatic) {
+  var disableMethods = this._disabledMethods;
+  var key = this.getKeyFromMethodNameAndTarget(fn, isStatic);
+  disableMethods[key] = true;
+}
+
+/**
+ * Get a key for the given method.
+ *
+ * @param {String} fn The function or method name
+ * @param {Boolean} isStatic
+ */
+
+SharedClass.prototype.getKeyFromMethodNameAndTarget = function(name, isStatic) {
+  return (isStatic ? '' : 'prototype.') + name;
 }
 
 function find(methods, fn, isStatic) {

--- a/test/shared-class.test.js
+++ b/test/shared-class.test.js
@@ -178,4 +178,39 @@ describe('SharedClass', function() {
       expect(classes).to.contain(CLASS_NAME);
     });
   });
+
+  describe('sharedClass.disableMethod(methodName, isStatic)', function () {
+    var sc;
+    var sm;
+    var METHOD_NAME = 'testMethod';
+    var INST_METHOD_NAME = 'instTestMethod';
+    var DYN_METHOD_NAME = 'dynMethod';
+
+    beforeEach(function() {
+      sc = new SharedClass('SomeClass', SomeClass);
+      sm = sc.defineMethod(METHOD_NAME, {isStatic: true});
+      sm = sc.defineMethod(INST_METHOD_NAME, {isStatic: false});
+      sc.resolve(function(define) {
+        define(DYN_METHOD_NAME, {isStatic: true});
+      });
+    });
+
+    it('excludes disabled static methods from the method list', function () {
+      sc.disableMethod(METHOD_NAME, true);
+      var methods = sc.methods().map(function(m) {return m.name});
+      expect(methods).to.not.contain(METHOD_NAME);
+    });
+
+    it('excludes disabled prototype methods from the method list', function () {
+      sc.disableMethod(INST_METHOD_NAME, false);
+      var methods = sc.methods().map(function(m) {return m.name});
+      expect(methods).to.not.contain(INST_METHOD_NAME);
+    });
+
+    it('excludes disabled dynamic (resolved) methods from the method list', function () {
+      sc.disableMethod(DYN_METHOD_NAME, true);
+      var methods = sc.methods().map(function(m) {return m.name});
+      expect(methods).to.not.contain(DYN_METHOD_NAME);
+    })
+;  });
 });


### PR DESCRIPTION
/to @raymondfeng 
/cc @bajtos 

This adds a blacklist which can be added to using `sharedClass.disableMethod(name, isStatic)`.

The blacklist is checked when building `sharedClass.methods()`.
