### PR TITLE
Honor toJSON/toXML() for XML support

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -254,6 +254,44 @@ HttpContext.prototype.invoke = function (scope, method, fn, isCtor) {
   }
 }
 
+function toJSON(input) {
+  if (!input) {
+    return input;
+  }
+  if (typeof input.toJSON === 'function') {
+    return input.toJSON();
+  } else if (Array.isArray(input)) {
+    return input.map(toJSON);
+  } else {
+    return input;
+  }
+}
+
+function toXML(input) {
+  var xml;
+  if (input && typeof input.toXML === 'function') {
+    xml = input.toXML();
+  } else {
+    if (input) {
+      // Trigger toJSON() conversions
+      input = toJSON(input);
+    }
+    if (Array.isArray(input)) {
+      input = { result: input };
+    }
+    xml = js2xmlparser('response', input, {
+      prettyPrinting: {
+        indentString: '  '
+      },
+      convertMap: {
+        '[object Date]': function(date) {
+          return date.toISOString();
+        }
+      }
+    });
+  }
+  return xml;
+}
 /**
  * Finish the request and send the correct response.
  */
@@ -264,6 +302,10 @@ HttpContext.prototype.done = function () {
   var data = this.result;
   var res = this.res;
   var accepts = this.req.accepts(SUPPORTED_TYPES);
+
+  if (this.req.query._format) {
+    accepts = this.req.query._format.toLowerCase();
+  }
   var dataExists = typeof data !== 'undefined';
 
   if(dataExists) {
@@ -280,7 +322,7 @@ HttpContext.prototype.done = function () {
       case 'application/xml':
       case 'text/xml':
       case 'xml':
-        if (accepts == 'application/xml') {
+        if (accepts === 'application/xml') {
           res.header('Content-Type', 'application/xml');
         } else {
           res.header('Content-Type', 'text/xml');
@@ -290,20 +332,7 @@ HttpContext.prototype.done = function () {
           res.end('<null/>');
         } else {
           try {
-            var input = data;
-            if (Object.prototype.toString.call(input) === '[object Array]') {
-              input = { result: data };
-            }
-            var xml = js2xmlparser('response', input, {
-              prettyPrinting: {
-                indentString: '  '
-              },
-              convertMap: {
-                '[object Date]': function (date) {
-                  return date.toISOString();
-                }
-              }
-            });
+            var xml = toXML(data);
             res.send(xml);
           } catch(e) {
             res.send(500, e + '\n' + data);

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -715,6 +715,212 @@ describe('strong-remoting-rest', function(){
       }
     });
 
+    describe('xml support', function() {
+
+      it('should produce xml from json objects', function(done) {
+        var method = givenSharedStaticMethod(
+          function bar(a, cb) {
+            cb(null, a);
+          },
+          {
+            accepts: [
+              { arg: 'a', type: 'object', http: {source: 'body' }  }
+            ],
+            returns: { arg: 'data', type: 'object', root: true },
+            http: { path: '/' }
+          }
+        );
+
+        request(app)['post'](method.classUrl)
+          .set('Accept', 'application/xml')
+          .set('Content-Type', 'application/json')
+          .send('{"x": 1, "y": "Y"}')
+          .expect('Content-Type', /xml/)
+          .expect(200, function(err, res) {
+            expect(res.text).to.equal('<?xml version="1.0" encoding="UTF-8"?>\n' +
+              '<response>\n  <x>1</x>\n  <y>Y</y>\n</response>');
+            done(err, res);
+          });
+      });
+
+      it('should produce xml from json array', function(done) {
+        var method = givenSharedStaticMethod(
+          function bar(cb) {
+            cb(null, [1, 2, 3]);
+          },
+          {
+            returns: { arg: 'data', type: ['number'], root: true },
+            http: { path: '/', verb: 'get'}
+          }
+        );
+
+        request(app)['get'](method.classUrl)
+          .set('Accept', 'application/xml')
+          .set('Content-Type', 'application/json')
+          .send('{"x": 1, "y": "Y"}')
+          .expect('Content-Type', /xml/)
+          .expect(200, function(err, res) {
+            expect(res.text).to.equal('<?xml version=\"1.0\" ' +
+              'encoding=\"UTF-8\"?>\n<response>\n  <result>1</result>\n  ' +
+              '<result>2</result>\n  <result>3</result>\n</response>');
+            done(err, res);
+          });
+      });
+
+      it('should produce xml from json objects with toJSON()', function(done) {
+        var method = givenSharedStaticMethod(
+          function bar(a, cb) {
+            var result = a;
+            a.toJSON = function() {
+              return {
+                foo: a.y,
+                bar: a.x
+              };
+            };
+            cb(null, a);
+          },
+          {
+            accepts: [
+              { arg: 'a', type: 'object', http: {source: 'body' }  }
+            ],
+            returns: { arg: 'data', type: 'object', root: true },
+            http: { path: '/' }
+          }
+        );
+
+        request(app)['post'](method.classUrl)
+          .set('Accept', 'application/xml')
+          .set('Content-Type', 'application/json')
+          .send('{"x": 1, "y": "Y"}')
+          .expect('Content-Type', /xml/)
+          .expect(200, function(err, res) {
+            expect(res.text).to.equal('<?xml version="1.0" encoding="UTF-8"?>\n' +
+              '<response>\n  <foo>Y</foo>\n  <bar>1</bar>\n</response>');
+            done(err, res);
+          });
+      });
+
+      it('should produce xml from json objects with toJSON() inside an array',
+        function(done) {
+        var method = givenSharedStaticMethod(
+          function bar(a, cb) {
+            a.toJSON = function() {
+              return {
+                foo: a.y,
+                bar: a.x
+              };
+            };
+            cb(null, [a, {c: 1}]);
+          },
+          {
+            accepts: [
+              { arg: 'a', type: 'object', http: {source: 'body' }  }
+            ],
+            returns: { arg: 'data', type: 'object', root: true },
+            http: { path: '/' }
+          }
+        );
+
+        request(app)['post'](method.classUrl)
+          .set('Accept', 'application/xml')
+          .set('Content-Type', 'application/json')
+          .send('{"x": 1, "y": "Y"}')
+          .expect('Content-Type', /xml/)
+          .expect(200, function(err, res) {
+            expect(res.text).to.equal('<?xml version=\"1.0\" ' +
+              'encoding=\"UTF-8\"?>\n<response>\n  <result>\n    ' +
+              '<foo>Y</foo>\n    <bar>1</bar>\n  </result>\n  <result>\n    ' +
+              '<c>1</c>\n  </result>\n</response>');
+            done(err, res);
+          });
+      });
+
+      it('should produce xml from json objects with toXML()', function(done) {
+        var method = givenSharedStaticMethod(
+          function bar(a, cb) {
+            var result = a;
+            a.toXML = function() {
+              return '<?xml version="1.0" encoding="UTF-8"?>' +
+                '<root><x>10</x></root>';
+            };
+            cb(null, a);
+          },
+          {
+            accepts: [
+              { arg: 'a', type: 'object', http: {source: 'body' }  }
+            ],
+            returns: { arg: 'data', type: 'object', root: true },
+            http: { path: '/' }
+          }
+        );
+
+        request(app)['post'](method.classUrl)
+          .set('Accept', 'application/xml')
+          .set('Content-Type', 'application/json')
+          .send('{"x": 1, "y": "Y"}')
+          .expect('Content-Type', /xml/)
+          .expect(200, function(err, res) {
+            expect(res.text).to.equal('<?xml version="1.0" encoding="UTF-8"?>' +
+              '<root><x>10</x></root>');
+            done(err, res);
+          });
+      });
+    });
+
+    describe('_format support', function() {
+
+      it('should produce xml if _format is xml', function(done) {
+        var method = givenSharedStaticMethod(
+          function bar(a, cb) {
+            cb(null, a);
+          },
+          {
+            accepts: [
+              { arg: 'a', type: 'object', http: {source: 'body' }  }
+            ],
+            returns: { arg: 'data', type: 'object', root: true },
+            http: { path: '/' }
+          }
+        );
+
+        request(app)['post'](method.classUrl+'?_format=xml')
+          .set('Accept', '*/*')
+          .set('Content-Type', 'application/json')
+          .send('{"x": 1, "y": "Y"}')
+          .expect('Content-Type', /xml/)
+          .expect(200, function(err, res) {
+            expect(res.text).to.equal('<?xml version="1.0" encoding="UTF-8"?>\n' +
+              '<response>\n  <x>1</x>\n  <y>Y</y>\n</response>');
+            done(err, res);
+          });
+      });
+
+      it('should produce json if _format is json', function(done) {
+        var method = givenSharedStaticMethod(
+          function bar(a, cb) {
+            cb(null, a);
+          },
+          {
+            accepts: [
+              { arg: 'a', type: 'object', http: {source: 'body' }  }
+            ],
+            returns: { arg: 'data', type: 'object', root: true },
+            http: { path: '/' }
+          }
+        );
+
+        request(app)['post'](method.classUrl+'?_format=json')
+          .set('Accept', 'application/xml')
+          .set('Content-Type', 'application/json')
+          .send('{"x": 1, "y": "Y"}')
+          .expect('Content-Type', /json/)
+          .expect(200, function(err, res) {
+            expect(res.body).to.deep.equal({x: 1, y: 'Y'});
+            done(err, res);
+          });
+      });
+    });
+
     describe('uncaught errors', function () {
       it('should return 500 if an error object is thrown', function (done) {
         remotes.shouldThrow = {


### PR DESCRIPTION
/to @ritch @bajtos 

The PR allows customization of JSON to XML conversion using toJSON()/toXML(). It also adds some test cases for XML media types.
