### PR TITLE
Supported types option

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -15,7 +15,7 @@ var EventEmitter = require('events').EventEmitter
   , assert = require('assert')
   , Dynamic = require('./dynamic')
   , js2xmlparser = require('js2xmlparser')
-  , SUPPORTED_TYPES = [
+  , DEFAULT_SUPPORTED_TYPES = [
     'application/json', 'application/javascript', 'application/xml',
     'text/javascript', 'text/xml',
     'json', 'xml',
@@ -30,12 +30,14 @@ var EventEmitter = require('events').EventEmitter
  * @class
  */
 
-function HttpContext(req, res, method) {
+function HttpContext(req, res, method, options) {
   this.req = req;
   this.res = res;
   this.method = method;
   this.args = this.buildArgs(method);
   this.methodString = method.stringName;
+  this.options = options || {};
+  this.supportedTypes = this.options.supportedTypes || DEFAULT_SUPPORTED_TYPES;
 }
 
 /**
@@ -263,7 +265,7 @@ HttpContext.prototype.done = function () {
   // the requested content type
   var data = this.result;
   var res = this.res;
-  var accepts = this.req.accepts(SUPPORTED_TYPES);
+  var accepts = this.req.accepts(this.supportedTypes);
   var dataExists = typeof data !== 'undefined';
 
   if(dataExists) {

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -369,7 +369,7 @@ RestAdapter.prototype._createStaticMethodHandler = function(sharedMethod) {
   var Context = this.Context;
 
   return function restStaticMethodHandler(req, res, next) {
-    var ctx = new Context(req, res, sharedMethod);
+    var ctx = new Context(req, res, sharedMethod, self.options);
     self._invokeMethod(ctx, sharedMethod, next);
   };
 };
@@ -379,7 +379,7 @@ RestAdapter.prototype._createPrototypeMethodHandler = function(sharedMethod) {
   var Context = this.Context;
 
   return function restPrototypeMethodHandler(req, res, next) {
-    var ctx = new Context(req, res, sharedMethod);
+    var ctx = new Context(req, res, sharedMethod, self.options);
 
     // invoke the shared constructor to get an instance
     ctx.invoke(sharedMethod.ctor, sharedMethod.sharedCtor, function(err, inst) {


### PR DESCRIPTION
Adds a supported types option to strong-remoting. See https://github.com/strongloop/strong-remoting/issues/118 for some background.

/cc @bajtos 
/cc @raymondfeng 
