### PR TITLE
rest-adapter: default options from remoting opts

### DIFF
--- a/lib/remote-objects.js
+++ b/lib/remote-objects.js
@@ -70,7 +70,7 @@ RemoteObjects.extend = function (exports) {
 
 RemoteObjects.prototype.handler = function (name, options) {
   var Adapter = this.adapter(name);
-  var adapter = new Adapter(this, options || {});
+  var adapter = new Adapter(this, options);
   var handler = adapter.createHandler();
   
   if(handler) {

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -28,7 +28,7 @@ var urlencoded = bodyParser.urlencoded;
 /**
  * Create a new `RestAdapter` with the given `options`.
  *
- * @param {Object} options
+ * @param {Object} [options] REST options, default to `remotes.options.rest`.
  * @return {RestAdapter}
  */
 
@@ -37,7 +37,7 @@ function RestAdapter(remotes, options) {
 
   this.remotes = remotes;
   this.Context = HttpContext;
-  this.options = options || {};
+  this.options = options || (remotes.options || {}).rest;
 }
 
 /**

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -141,6 +141,32 @@ describe('strong-remoting-rest', function(){
         .end(expectErrorResponseContaining({message: 'test-error'}, ['stack'], done));
     });
 
+    it('should configure custom REST content types', function(done) {
+      var supportedTypes = ['json', 'application/javascript', 'text/javascript'];
+      objects.options.rest = { supportedTypes: supportedTypes };
+
+      var method = givenSharedStaticMethod(
+        function(cb) {
+          cb(null, {key: 'value'});
+        },
+        {
+          returns: { arg: 'result', type: 'object' }
+        }
+      );
+
+      var browserAcceptHeader = [
+        'text/html',
+        'application/xhtml+xml',
+        'application/xml;q=0.9',
+        'image/webp',
+        '*/*;q=0.8'
+      ].join(',');
+
+      request(app).get(method.url)
+        .set('Accept', browserAcceptHeader)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+        .expect(200, done);
+    });
   });
 
   describe('cors', function() {


### PR DESCRIPTION
Modify RestAdapter to use `remotes.options.rest` when no explicit options were specified.

This makes the configuration option `supportedTypes` consistent with other options like `errorHandler` or `json` that are set via `remotes.options.{name}`.

A follow-up for #121 as a part of #118.

/to @raymondfeng please review
/cc @gcirne 
