### PR TITLE
Fix the jsonrpc adapter to reference the method correctly

### DIFF
--- a/lib/jsonrpc-adapter.js
+++ b/lib/jsonrpc-adapter.js
@@ -142,10 +142,10 @@ JsonRpcAdapter.prototype.createHandler = function () {
       var fn = function () {
         var args = arguments;
         if (method.isStatic) {
-          method.fn.apply(method.ctor, args);
+          method.getFunction().apply(method.ctor, args);
         } else {
           method.sharedCtor.invoke(method, function (err, instance) {
-            method.fn.apply(instance, args);
+            method.getFunction().apply(instance, args);
           });
         }
       };

--- a/test/jsonrpc.test.js
+++ b/test/jsonrpc.test.js
@@ -2,6 +2,7 @@ var assert = require('assert');
 var RemoteObjects = require('../');
 var express = require('express');
 var request = require('supertest');
+var SharedClass = require('../lib/shared-class');
 
 describe('strong-remoting-jsonrpc', function () {
   var app;
@@ -37,21 +38,38 @@ describe('strong-remoting-jsonrpc', function () {
           fn(null, msg);
         }
 
+        // Create a shared method directly on the function object
         remotes.user = {
           greet: greet
         };
-
         greet.shared = true;
+
+        // Create a shared method using SharedClass/SharedMethod
+        function Product() {
+        }
+
+        Product.getPrice = function(cb) {
+          process.nextTick(function() {
+            return cb(null, 100);
+          });
+        };
+
+        var productClass = new SharedClass('product', Product, {});
+        productClass.defineMethod('getPrice', {isStatic: true});
+        objects.addClass(productClass);
       });
 
       it('should support calling object methods', function (done) {
-
         jsonrpc('/user/jsonrpc', 'greet', ['JS'])
           .expect({"jsonrpc": "2.0", "id": 1, "result": "JS"}, done);
       });
 
-      it('should report error for non-existent methods', function (done) {
+      it('should support a remote method using shared method', function (done) {
+        jsonrpc('/product/jsonrpc', 'getPrice', [])
+          .expect({"jsonrpc": "2.0", "id": 1, "result": 100}, done);
+      });
 
+      it('should report error for non-existent methods', function (done) {
         jsonrpc('/user/jsonrpc', 'greet1', ['JS'])
           .expect({
             "jsonrpc": "2.0",
@@ -65,7 +83,6 @@ describe('strong-remoting-jsonrpc', function () {
 
       // The 1kb limit is set by RemoteObjects.create({json: {limit: '1kb'}});
       it('should reject json payload larger than 1kb', function (done) {
-
         // Build an object that is larger than 1kb
         var name = "";
         for (var i = 0; i < 2048; i++) {


### PR DESCRIPTION
/to @ritch 

See https://github.com/strongloop/strong-remoting/issues/124

To enable the jsonrpc adapter, add the following to server/boot/json-rpc.js

``` js
module.exports = function(app) {
  app.use('/services', app.handler('jsonrpc'));
}
```

It will expose `POST /services/my-model/jsonrpc` as jsonrpc endpoints.

To invoke the method:

``` sh
curl -X POST -d '{"jsonrpc": "2.0", "method": "find", "id": "1"}' http://127.0.0.1:3000/services/my-model/jsonrpc -H 'Accept: application/json' -H 'Content-Type: application/json' --verbose 
```
