### PR TITLE
Fix use of loose falsy comparison when getting arguments in HttpContext.

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -143,7 +143,9 @@ HttpContext.prototype.getArgByName = function (name, options) {
     args = {};
   }
 
-  var arg = (args && args[name]) || this.req.param(name) || this.req.get(name);
+  var arg = (args && args[name] !== undefined) ? args[name] :
+            this.req.param(name) !== undefined ? this.req.param(name) :
+            this.req.get(name);
   // search these in order by name
   // req.params
   // req.body

--- a/test/rest.browser.test.js
+++ b/test/rest.browser.test.js
@@ -225,6 +225,61 @@ describe('strong-remoting-rest', function(){
           done();
         });
       });
+
+      it('should allow and return falsy required arguments of correct type', function(done) {
+        var method = givenSharedStaticMethod(
+          function bar(num, str, bool, cb) {
+            cb(null, num, str, bool);
+          },
+          {
+            accepts: [
+              { arg: 'num', type: 'number', required: true },
+              { arg: 'str', type: 'string', required: true },
+              { arg: 'bool', type: 'boolean', required: true }
+            ],
+            returns: [
+              { arg: 'num', type: 'number' },
+              { arg: 'str', type: 'string' },
+              { arg: 'bool', type: 'boolean' }
+            ],
+            http: { path: '/' }
+          }
+        );
+        
+        objects.invoke(method.name, [0, '', false], function(err, a, b, c) {
+          expect(err).to.not.be.an.instanceof(Error);
+          assert.equal(a, 0);
+          assert.equal(b, '');
+          assert.equal(c, false);
+          done();
+        });
+      });
+
+      it('should reject falsy required arguments of incorrect type', function(done) {
+        var method = givenSharedStaticMethod(
+          function bar(num, str, bool, cb) {
+            cb(null, num, str, bool);
+          },
+          {
+            accepts: [
+              { arg: 'num', type: 'number', required: true },
+              { arg: 'str', type: 'string', required: true },
+              { arg: 'bool', type: 'boolean', required: true }
+            ],
+            returns: [
+              { arg: 'num', type: 'number' },
+              { arg: 'str', type: 'string' },
+              { arg: 'bool', type: 'boolean' }
+            ],            
+            http: { path: '/' }
+          }
+        );
+        
+        objects.invoke(method.name, ['', false, 0], function(err, a, b, c) {
+          expect(err).to.be.an.instanceof(Error);
+          done();
+        });
+      });
       
       describe('uncaught errors', function () {
         it('should return 500 if an error object is thrown', function (done) {


### PR DESCRIPTION
This would cause problems when e.g. sending a required number arg that equaled 0, or a boolean that equaled false. It would not be found by HttpContext#getArgByName, so the invocation would then fail a required check, even though 0 or false is perfectly valid input.

Added test cases to ensure this doesn't happen again. 
