### PR TITLE
SharedMethod: add flag `documented` [GoDaddy]

### DIFF
--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -473,6 +473,7 @@ RestAdapter.prototype.allRoutes = function () {
       path: path,
       description: method.description,
       notes: method.notes,
+      documented: method.documented,
       method: method.stringName,
       accepts: (method.accepts && method.accepts.length) ? method.accepts : undefined,
       returns: (method.returns && method.returns.length) ? method.returns : undefined,
@@ -520,6 +521,7 @@ function RestMethod(restClass, sharedMethod) {
   this.errors = sharedMethod.errors;
   this.description = sharedMethod.description;
   this.notes = sharedMethod.notes;
+  this.documented = sharedMethod.documented;
 
   var methodRoutes = getRoutes(sharedMethod);
   if (sharedMethod.isStatic || !restClass.ctor) {

--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -57,6 +57,8 @@ var debug = require('debug')('strong-remoting:shared-method')
  * @property {String} http
  * @property {String} rest
  * @property {String} shared
+ * @property {Boolean} [documented] Default: true. Set to `false` to exclude
+ *   the method from Swagger metadata.
  */
 
 function SharedMethod(fn, name, sc, options) {
@@ -76,6 +78,7 @@ function SharedMethod(fn, name, sc, options) {
   this.errors = options.errors || fn.errors || [];
   this.description = options.description || fn.description;
   this.notes = options.notes || fn.notes;
+  this.documented = (options.documented || fn.documented) !== false;
   this.http = options.http || fn.http || {};
   this.rest = options.rest || fn.rest || {};
   this.shared = options.shared;

--- a/test/rest-adapter.test.js
+++ b/test/rest-adapter.test.js
@@ -137,6 +137,16 @@ describe('RestAdapter', function() {
       expect(method.notes).to.equal('some-notes');
     });
 
+    it('has `documented`', function() {
+      var method = givenRestStaticMethod({ documented: false });
+      expect(method.documented).to.equal(false);
+    });
+
+    it('has `documented:true` by default', function() {
+      var method = givenRestStaticMethod();
+      expect(method.documented).to.equal(true);
+    });
+
     describe('isReturningArray()', function() {
       it('returns true when there is single root Array arg', function() {
         var method = givenRestStaticMethod({


### PR DESCRIPTION
The flag is `true` by default and controls whether the method should be included in swagger descriptor generated by loopback-explorer.

This is a follow-up PR for #131 implementing the requested feature in the right way.

/to @raymondfeng please review
/cc @ritch @shelbys @dashby3000 
