### PR TITLE
Add `options.rest.xml`, disable XML by default

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -38,6 +38,13 @@ function HttpContext(req, res, method, options) {
   this.methodString = method.stringName;
   this.options = options || {};
   this.supportedTypes = this.options.supportedTypes || DEFAULT_SUPPORTED_TYPES;
+
+  if (this.supportedTypes === DEFAULT_SUPPORTED_TYPES && !this.options.xml) {
+    // Disable all XML-based types by default
+    this.supportedTypes = this.supportedTypes.filter(function(type) {
+      return !/\bxml\b/i.test(type);
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
Add an option `rest.xml` that quickly enables/disables support for responses in XML format.

The XML support is disabled by default now.

Versions `2.7.1` and newer has XML output enabled by default (see #111), which causes requests made from a browser to be handled with XML response type.

Such behaviour was considered as a breaking change when compared to `2.7.0`, see #118. This commit restores the behaviour of `2.7.0`.

/to @raymondfeng please review
/cc @ritch @gcirne @pungoyal FYI

**Note**

Once landed, we should release a new **minor** version and post a message to loopback mailing list to explain the situation, the consequences of this change and how to upgrade applications that are actually depending on the XML format.

**Upgrade instructions**

Modify you `server/config.json` and add `remoting.rest.xml: true`. Example:

``` json
{
  "host": "0.0.0.0",
  "port": 3000,
  "remoting": {
    "rest": {
      "xml": true
    }
  }
}
```

@shelbys @dashby3000 GoDaddy will be affected by this change and have to modify their `server/config.json` file before installing a new strong-remoting version.
