### PR TITLE
Enable jshint and jscs

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,21 @@
+{
+  "preset": "google",
+  "requireCurlyBraces": [
+     "for",
+     "while",
+     "do",
+     "try",
+     "catch"
+  ],
+  "disallowSpacesInsideObjectBrackets": null,
+  "maximumLineLength": {
+     "value": 92,
+     "allowComments": false,
+     "allowRegex": true
+  },
+  "validateJSDoc": {
+    "checkParamNames": false,
+    "checkRedundantParams": false,
+    "requireParamTypes": true
+  }
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -5,8 +5,6 @@
 "indent": 2,
 "undef": true,
 "quotmark": "single",
-"maxlen": 92,
-"trailing": true,
 "newcap": true,
 "nonew": true,
 "undef": true,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,18 +36,23 @@ module.exports = function(grunt) {
         src: ['test/**/*.js']
       }
     },
+    jscs: {
+      gruntfile: 'Gruntfile.js',
+      lib: '<%= jshint.lib.src %>',
+      test: '<%= jshint.lib.src %>'
+    },
     watch: {
       gruntfile: {
         files: '<%= jshint.gruntfile.src %>',
-        tasks: ['jshint:gruntfile']
+        tasks: ['jshint:gruntfile', 'jscs:gruntfile']
       },
       lib: {
         files: '<%= jshint.lib.src %>',
-        tasks: ['jshint:lib']
+        tasks: ['jshint:lib', 'jscs:lib']
       },
       test: {
         files: '<%= jshint.test.src %>',
-        tasks: ['jshint:test']
+        tasks: ['jshint:test', 'jscs:test']
       }
     },
     browserify: {
@@ -150,11 +155,11 @@ module.exports = function(grunt) {
     require('test/e2e/e2e-server.js');
   });
 
-
   // These plugins provide necessary tasks.
   grunt.loadNpmTasks('grunt-browserify');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-jscs');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-karma');
 

--- a/lib/dynamic.js
+++ b/lib/dynamic.js
@@ -8,8 +8,8 @@ module.exports = Dynamic;
  * Module dependencies.
  */
 
-var debug = require('debug')('strong-remoting:dynamic')
-  , assert = require('assert');
+var debug = require('debug')('strong-remoting:dynamic');
+var assert = require('assert');
 
 /**
  * Create a dynamic value from the given value.
@@ -36,7 +36,7 @@ Dynamic.converters = [];
  * ```js
  * Dynamic.define('MyType', function(val, ctx) {
  *   // use the val and ctx objects to return the concrete value
- *   return new MyType(val); 
+ *   return new MyType(val);
  * });
  * ```
  *
@@ -51,7 +51,7 @@ Dynamic.define = function(name, converter) {
 
 /**
  * Is the given type supported.
- * 
+ *
  * @param {String} type
  * @returns {Boolean}
  */
@@ -62,7 +62,7 @@ Dynamic.canConvert = function(type) {
 
 /**
  * Get converter by type name.
- * 
+ *
  * @param {String} type
  * @returns {Function}
  */
@@ -70,9 +70,9 @@ Dynamic.canConvert = function(type) {
 Dynamic.getConverter = function(type) {
   var converters = this.converters;
   var converter;
-  for(var i = 0; i < converters.length; i++) {
+  for (var i = 0; i < converters.length; i++) {
     converter = converters[i];
-    if(converter.typeName === type) {
+    if (converter.typeName === type) {
       return converter;
     }
   }
@@ -80,7 +80,7 @@ Dynamic.getConverter = function(type) {
 
 /**
  * Convert the dynamic value to the given type.
- * 
+ *
  * @param {String} type
  * @returns {*} The concrete value
  */
@@ -96,9 +96,9 @@ Dynamic.prototype.to = function(type) {
  */
 
 Dynamic.define('boolean', function convertBoolean(val) {
-  switch(typeof val) {
+  switch (typeof val) {
     case 'string':
-      switch(val) {
+      switch (val) {
         case 'false':
         case 'undefined':
         case 'null':
@@ -117,7 +117,7 @@ Dynamic.define('boolean', function convertBoolean(val) {
 });
 
 Dynamic.define('number', function convertNumber(val) {
-  if(val === 0) return val;
-  if(!val) return val;
+  if (val === 0) return val;
+  if (!val) return val;
   return Number(val);
 });

--- a/lib/exports-helper.js
+++ b/lib/exports-helper.js
@@ -39,7 +39,7 @@ function setPath(path, value) {
   var split = path.split('.');
   var name = split.pop();
 
-  split.forEach(function (key) {
+  split.forEach(function(key) {
     if (!obj[key]) {
       obj[key] = {};
     }
@@ -73,7 +73,7 @@ function type(fn, options) {
     // TODO(schoon) - This shouldn't be thought of (or named) as a "shared
     // constructor". Instead, this is the lazy find/create sl-remoting uses when
     // a prototype method is called. `getInstance`? `findOrCreate`? `load`?
-    sharedCtor = function () {
+    sharedCtor = function() {
       var _args = [].slice.call(arguments);
       _args.pop()(null, fn.apply(null, _args));
     };
@@ -89,7 +89,7 @@ function type(fn, options) {
     sharedCtor.returns = { type: 'object', root: true };
   }
 
-  PASSTHROUGH_OPTIONS.forEach(function (key) {
+  PASSTHROUGH_OPTIONS.forEach(function(key) {
     if (options[key]) {
       sharedCtor[key] = options[key];
     }
@@ -125,7 +125,7 @@ function method(fn, options) {
   fn.returns = returns;
   fn.errors = errors;
 
-  PASSTHROUGH_OPTIONS.forEach(function (key) {
+  PASSTHROUGH_OPTIONS.forEach(function(key) {
     if (options[key]) {
       fn[key] = options[key];
     }

--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -8,14 +8,14 @@ module.exports = HttpContext;
  * Module dependencies.
  */
 
-var EventEmitter = require('events').EventEmitter
-  , debug = require('debug')('strong-remoting:http-context')
-  , util = require('util')
-  , inherits = util.inherits
-  , assert = require('assert')
-  , Dynamic = require('./dynamic')
-  , js2xmlparser = require('js2xmlparser')
-  , DEFAULT_SUPPORTED_TYPES = [
+var EventEmitter = require('events').EventEmitter;
+var debug = require('debug')('strong-remoting:http-context');
+var util = require('util');
+var inherits = util.inherits;
+var assert = require('assert');
+var Dynamic = require('./dynamic');
+var js2xmlparser = require('js2xmlparser');
+var DEFAULT_SUPPORTED_TYPES = [
     'application/json', 'application/javascript', 'application/xml',
     'text/javascript', 'text/xml',
     'json', 'xml',
@@ -57,7 +57,7 @@ inherits(HttpContext, EventEmitter);
  * Build args object from the http context's `req` and `res`.
  */
 
-HttpContext.prototype.buildArgs = function (method) {
+HttpContext.prototype.buildArgs = function(method) {
   var args = {};
   var ctx = this;
   var accepts = method.accepts;
@@ -65,19 +65,19 @@ HttpContext.prototype.buildArgs = function (method) {
   var errors = method.errors;
 
   // build arguments from req and method options
-  accepts.forEach(function (o) {
+  accepts.forEach(function(o) {
     var httpFormat = o.http;
     var name = o.name || o.arg;
     var val;
 
-    if(httpFormat) {
-      switch(typeof httpFormat) {
+    if (httpFormat) {
+      switch (typeof httpFormat) {
         case 'function':
           // the options have defined a formatter
           val = httpFormat(this);
           break;
         case 'object':
-          switch(httpFormat.source) {
+          switch (httpFormat.source) {
             case 'body':
               val = this.req.body;
               break;
@@ -119,7 +119,7 @@ HttpContext.prototype.buildArgs = function (method) {
     var dynamic;
     var otype = (typeof o.type === 'string') && o.type.toLowerCase();
 
-    if(Dynamic.canConvert(otype)) {
+    if (Dynamic.canConvert(otype)) {
       dynamic = new Dynamic(val, ctx);
       val = dynamic.to(otype);
     }
@@ -138,15 +138,15 @@ HttpContext.prototype.buildArgs = function (method) {
  * @param {Object} options **optional**
  */
 
-HttpContext.prototype.getArgByName = function (name, options) {
+HttpContext.prototype.getArgByName = function(name, options) {
   var req = this.req;
   var args = req.param('args');
 
-  if(args) {
+  if (args) {
     args = JSON.parse(args);
   }
 
-  if(typeof args !== 'object' || !args) {
+  if (typeof args !== 'object' || !args) {
     args = {};
   }
 
@@ -159,9 +159,8 @@ HttpContext.prototype.getArgByName = function (name, options) {
   // req.query
   // req.header
 
-
   // coerce simple types in objects
-  if(typeof arg === 'object') {
+  if (typeof arg === 'object') {
     arg = coerceAll(arg);
   }
 
@@ -181,7 +180,7 @@ var isint = /^[0-9]+$/;
 var isfloat = /^([0-9]+)?\.[0-9]+$/;
 
 function coerce(str) {
-  if(typeof str != 'string') return str;
+  if (typeof str != 'string') return str;
   if ('null' == str) return null;
   if ('true' == str) return true;
   if ('false' == str) return false;
@@ -194,18 +193,18 @@ function coerce(str) {
 function coerceAll(obj) {
   var type = Array.isArray(obj) ? 'array' : typeof obj;
 
-  switch(type) {
+  switch (type) {
     case 'string':
       return coerce(obj);
     case 'object':
-      if(obj) {
-        Object.keys(obj).forEach(function (key) {
+      if (obj) {
+        Object.keys(obj).forEach(function(key) {
           obj[key] = coerceAll(obj[key]);
         });
       }
       break;
     case 'array':
-      obj.map(function (o) {
+      obj.map(function(o) {
         return coerceAll(o);
       });
       break;
@@ -218,12 +217,12 @@ function coerceAll(obj) {
  * Invoke the given shared method using the provided scope against the current context.
  */
 
-HttpContext.prototype.invoke = function (scope, method, fn, isCtor) {
+HttpContext.prototype.invoke = function(scope, method, fn, isCtor) {
   var args = this.args;
-  if(isCtor) {
+  if (isCtor) {
     try {
       args = this.buildArgs(method);
-    } catch(err) {
+    } catch (err) {
       // JSON.parse() might throw
       return fn(err);
     }
@@ -233,9 +232,9 @@ HttpContext.prototype.invoke = function (scope, method, fn, isCtor) {
   var pipeDest = pipe && pipe.dest;
   var pipeSrc = pipe && pipe.source;
 
-  if(pipeDest) {
+  if (pipeDest) {
     // only support response for now
-    switch(pipeDest) {
+    switch (pipeDest) {
       case 'res':
         // Probably not correct...but passes my test.
         this.res.header('Content-Type', 'application/json');
@@ -248,9 +247,9 @@ HttpContext.prototype.invoke = function (scope, method, fn, isCtor) {
         fn(new Error('unsupported pipe destination'));
         break;
     }
-  } else if(pipeSrc) {
+  } else if (pipeSrc) {
     // only support request for now
-    switch(pipeDest) {
+    switch (pipeDest) {
       case 'req':
         this.req.pipe(method.invoke(scope, args, fn));
         break;
@@ -306,7 +305,7 @@ function toXML(input) {
  * Finish the request and send the correct response.
  */
 
-HttpContext.prototype.done = function () {
+HttpContext.prototype.done = function() {
   // send the result back as
   // the requested content type
   var data = this.result;
@@ -318,8 +317,8 @@ HttpContext.prototype.done = function () {
   }
   var dataExists = typeof data !== 'undefined';
 
-  if(dataExists) {
-    switch(accepts) {
+  if (dataExists) {
+    switch (accepts) {
       case '*/*':
       case 'application/json':
       case 'json':
@@ -344,7 +343,7 @@ HttpContext.prototype.done = function () {
           try {
             var xml = toXML(data);
             res.send(xml);
-          } catch(e) {
+          } catch (e) {
             res.send(500, e + '\n' + data);
           }
         }

--- a/lib/http-invocation.js
+++ b/lib/http-invocation.js
@@ -8,17 +8,16 @@ module.exports = HttpInvocation;
  * Module dependencies.
  */
 
-var EventEmitter = require('events').EventEmitter
-  , debug = require('debug')('strong-remoting:http-invocation')
-  , util = require('util')
-  , inherits = util.inherits
-  , path = require('path')
-  , assert = require('assert')
-  , request = require('request')
-  , Dynamic = require('./dynamic')
-  , SUPPORTED_TYPES = ['json', 'application/javascript', 'text/javascript']
-  , qs = require('qs');
-
+var EventEmitter = require('events').EventEmitter;
+var debug = require('debug')('strong-remoting:http-invocation');
+var util = require('util');
+var inherits = util.inherits;
+var path = require('path');
+var assert = require('assert');
+var request = require('request');
+var Dynamic = require('./dynamic');
+var SUPPORTED_TYPES = ['json', 'application/javascript', 'text/javascript'];
+var qs = require('qs');
 
 /*!
  * JSON Types
@@ -52,7 +51,7 @@ function HttpInvocation(method, ctorArgs, args, base) {
   if (!this.isStatic) {
     method.restClass.ctor.accepts.forEach(function(accept) {
       val = ctorArgs.shift();
-      if(HttpInvocation.isAcceptable(val, accept)) {
+      if (HttpInvocation.isAcceptable(val, accept)) {
         namedArgs[accept.arg || accept.name] = val;
       }
     });
@@ -60,7 +59,7 @@ function HttpInvocation(method, ctorArgs, args, base) {
 
   method.accepts.forEach(function(accept) {
     val = args.shift();
-    if(HttpInvocation.isAcceptable(val, accept)) {
+    if (HttpInvocation.isAcceptable(val, accept)) {
       namedArgs[accept.arg || accept.name] = val;
     }
   });
@@ -80,13 +79,13 @@ HttpInvocation.isAcceptable = function(val, accept) {
   var acceptArray = Array.isArray(accept.type) || accept.type.toLowerCase() === 'array';
   var type = acceptArray ? 'array' : accept.type && accept.type.toLowerCase();
   var strict = type && type !== 'any';
-  
-  if(acceptArray) {
+
+  if (acceptArray) {
     return Array.isArray(val);
   }
 
-  if(strict) {
-    if(JSON_TYPES.indexOf(type) === -1) {
+  if (strict) {
+    if (JSON_TYPES.indexOf(type) === -1) {
       return typeof val === 'object';
     }
     return (typeof val).toLowerCase() === type;
@@ -95,7 +94,7 @@ HttpInvocation.isAcceptable = function(val, accept) {
   }
 };
 
-HttpInvocation.prototype._processArg = function (req, verb, query, accept) {
+HttpInvocation.prototype._processArg = function(req, verb, query, accept) {
   var httpFormat = accept.http;
   var name = accept.name || accept.arg;
   var val = this.getArgByName(name);
@@ -154,7 +153,7 @@ HttpInvocation.prototype._processArg = function (req, verb, query, accept) {
  * Build args object from the http context's `req` and `res`.
  */
 
-HttpInvocation.prototype.createRequest = function () {
+HttpInvocation.prototype.createRequest = function() {
   var args = {};
   var method = this.method;
   var verb = method.getHttpMethod();
@@ -181,7 +180,7 @@ HttpInvocation.prototype.createRequest = function () {
     query = this._processArg(req, verb, query, accepts[i]);
   }
 
-  if(query) {
+  if (query) {
     req.url += '?' + qs.stringify(query);
   }
 
@@ -194,7 +193,7 @@ HttpInvocation.prototype.createRequest = function () {
  * @param {String} name
  */
 
-HttpInvocation.prototype.getArgByName = function (name) {
+HttpInvocation.prototype.getArgByName = function(name) {
   return this.namedArgs[name];
 };
 
@@ -202,13 +201,13 @@ HttpInvocation.prototype.getArgByName = function (name) {
  * Start the invocation.
  */
 
-HttpInvocation.prototype.invoke = function (callback) {
+HttpInvocation.prototype.invoke = function(callback) {
   var req = this.createRequest();
   request(req, function(err, res, body) {
-    if(err instanceof SyntaxError) {
-      if(res.status === 204) err = null;
+    if (err instanceof SyntaxError) {
+      if (res.status === 204) err = null;
     }
-    if(err) return callback(err);
+    if (err) return callback(err);
     this.transformResponse(res, body, callback);
   }.bind(this));
 };
@@ -234,8 +233,8 @@ HttpInvocation.prototype.transformResponse = function(res, body, callback) {
     res: res
   };
 
-  if(hasError) {
-    if(isObject && body.error) {
+  if (hasError) {
+    if (isObject && body.error) {
       err = new Error(body.error.message);
       err.name = body.error.name;
       err.stack = body.error.stack;
@@ -248,20 +247,20 @@ HttpInvocation.prototype.transformResponse = function(res, body, callback) {
   }
 
   // build request args and method options
-  returns.forEach(function (ret) {
+  returns.forEach(function(ret) {
     var httpFormat = ret.http;
     var name = ret.name || ret.arg;
     var val;
     var dynamic;
     var type = ret.type;
 
-    if(ret.root) {
+    if (ret.root) {
       val = res.body;
     } else {
       val = res.body[name];
     }
 
-    if(Dynamic.canConvert(type)) {
+    if (Dynamic.canConvert(type)) {
       dynamic = new Dynamic(val, ctx);
       val = dynamic.to(type);
     }

--- a/lib/jsonrpc-adapter.js
+++ b/lib/jsonrpc-adapter.js
@@ -8,15 +8,15 @@ module.exports = JsonRpcAdapter;
  * Module dependencies.
  */
 
-var EventEmitter = require('events').EventEmitter
-  , debug = require('debug')('strong-remoting:jsonrpc-adapter')
-  , util = require('util')
-  , inherits = util.inherits
-  , jayson = require('jayson')
-  , express = require('express')
-  , bodyParser = require('body-parser')
-  , cors = require('cors')
-  , HttpContext = require('./http-context');
+var EventEmitter = require('events').EventEmitter;
+var debug = require('debug')('strong-remoting:jsonrpc-adapter');
+var util = require('util');
+var inherits = util.inherits;
+var jayson = require('jayson');
+var express = require('express');
+var bodyParser = require('body-parser');
+var cors = require('cors');
+var HttpContext = require('./http-context');
 
 var json = bodyParser.json;
 var urlencoded = bodyParser.urlencoded;
@@ -46,7 +46,7 @@ inherits(JsonRpcAdapter, EventEmitter);
  */
 
 JsonRpcAdapter.create =
-  JsonRpcAdapter.createJsonRpcAdapter = function (remotes) {
+  JsonRpcAdapter.createJsonRpcAdapter = function(remotes) {
     // add simplified construction / sugar here
     return new JsonRpcAdapter(remotes);
   };
@@ -55,7 +55,7 @@ JsonRpcAdapter.create =
  * Get the path for the given method.
  */
 
-JsonRpcAdapter.prototype.getRoutes = function (obj) {
+JsonRpcAdapter.prototype.getRoutes = function(obj) {
   // build default route
   var routes = [
     {
@@ -68,7 +68,7 @@ JsonRpcAdapter.prototype.getRoutes = function (obj) {
 
 JsonRpcAdapter.errorHandler = function() {
   return function restErrorHandler(err, req, res, next) {
-    if(typeof err === 'string') {
+    if (typeof err === 'string') {
       err = new Error(err);
       err.status = err.statusCode = 500;
     }
@@ -82,8 +82,9 @@ JsonRpcAdapter.errorHandler = function() {
       message: err.message || 'An unknown error occurred'
     };
 
-    for (var prop in err)
+    for (var prop in err) {
       data[prop] = err[prop];
+    }
 
     // TODO(bajtos) Remove stack info when running in production
     data.stack = err.stack;
@@ -96,13 +97,13 @@ JsonRpcAdapter.errorHandler = function() {
   };
 };
 
-JsonRpcAdapter.prototype.createHandler = function () {
+JsonRpcAdapter.prototype.createHandler = function() {
 
   var root = express.Router();
   var classes = this.remotes.classes();
 
   // Add a handler to tolerate empty json as connect's json middleware throws an error
-  root.use(function (req, res, next) {
+  root.use(function(req, res, next) {
     if (req.is('application/json')) {
       if (req.get('Content-Length') === '0') {
         // This doesn't cover the transfer-encoding: chunked
@@ -135,45 +136,42 @@ JsonRpcAdapter.prototype.createHandler = function () {
 
   root.use(JsonRpcAdapter.errorHandler());
 
-  classes.forEach(function (sc) {
+  classes.forEach(function(sc) {
     var server = new jayson.server();
     root.post('/' + sc.name + '/jsonrpc',
       new jayson.server.interfaces.middleware(server, {}));
 
     var methods = sc.methods();
 
-    methods.forEach(function (method) {
+    methods.forEach(function(method) {
       // Wrap the method so that it will keep its own receiver - the shared class
-      var fn = function () {
+      var fn = function() {
         var args = arguments;
         if (method.isStatic) {
           method.getFunction().apply(method.ctor, args);
         } else {
-          method.sharedCtor.invoke(method, function (err, instance) {
+          method.sharedCtor.invoke(method, function(err, instance) {
             method.getFunction().apply(instance, args);
           });
         }
       };
-      
+
       /*
       I had to this because jayson uses fn.toString to map the parameters,
       and since you wrap the method, the jsonrpc server cannot read them.
       I solved this overwriting the toString method on the wrapped function,
       creating this fake string that has the paramenters names in it.
       */
-      if(method.accepts)
-      {
-        var argsNames = method.accepts.map(function(item)
-        {
+      if (method.accepts) {
+        var argsNames = method.accepts.map(function(item) {
           return item.arg;
         });
-  
-        fn.toString = function()
-        {
+
+        fn.toString = function() {
           return 'function (' + argsNames.concat('callback').join(',') + '){}';
         };
       }
-      
+
       server.method(method.name, fn);
     });
 
@@ -182,37 +180,34 @@ JsonRpcAdapter.prototype.createHandler = function () {
   return root;
 };
 
-
-JsonRpcAdapter.prototype.allRoutes = function () {
+JsonRpcAdapter.prototype.allRoutes = function() {
   var routes = [];
   var adapter = this;
   var classes = this.remotes.classes();
   var currentRoot = '';
 
-  classes.forEach(function (sc) {
-
-
+  classes.forEach(function(sc) {
     adapter
       .getRoutes(sc)
-      .forEach(function (classRoute) {
+      .forEach(function(classRoute) {
         currentRoot = classRoute.path;
         var methods = sc.methods();
 
         var functions = [];
-        methods.forEach(function (method) {
+        methods.forEach(function(method) {
           // Use functions to keep track of JS functions to dedupe
           if (functions.indexOf(method.fn) === -1) {
             functions.push(method.fn);
           } else {
             return; // Skip duplicate methods such as X.m1 = X.m2 = function() {...}
           }
-          adapter.getRoutes(method).forEach(function (route) {
+          adapter.getRoutes(method).forEach(function(route) {
             if (method.isStatic) {
               addRoute(route.verb, route.path, method);
             } else {
               adapter
                 .getRoutes(method.sharedCtor)
-                .forEach(function (sharedCtorRoute) {
+                .forEach(function(sharedCtorRoute) {
                   addRoute(route.verb, sharedCtorRoute.path + route.path, method);
                 });
             }
@@ -222,7 +217,6 @@ JsonRpcAdapter.prototype.allRoutes = function () {
   });
 
   return routes;
-
 
   function addRoute(verb, path, method) {
     if (path === '/' || path === '//') {
@@ -250,4 +244,3 @@ JsonRpcAdapter.prototype.allRoutes = function () {
     });
   }
 };
-

--- a/lib/remote-objects.js
+++ b/lib/remote-objects.js
@@ -8,14 +8,14 @@ module.exports = RemoteObjects;
  * Module dependencies.
  */
 
-var EventEmitter = require('eventemitter2').EventEmitter2
-  , debug = require('debug')('strong-remoting:remotes')
-  , util = require('util')
-  , inherits = util.inherits
-  , assert = require('assert')
-  , Dynamic = require('./dynamic')
-  , SharedClass = require('./shared-class')
-  , ExportsHelper = require('./exports-helper');
+var EventEmitter = require('eventemitter2').EventEmitter2;
+var debug = require('debug')('strong-remoting:remotes');
+var util = require('util');
+var inherits = util.inherits;
+var assert = require('assert');
+var Dynamic = require('./dynamic');
+var SharedClass = require('./shared-class');
+var ExportsHelper = require('./exports-helper');
 
 // require the rest adapter for browserification
 // TODO(ritch) remove this somehow...?
@@ -52,11 +52,11 @@ inherits(RemoteObjects, EventEmitter);
  * Simplified APIs
  */
 
-RemoteObjects.create = function (options) {
+RemoteObjects.create = function(options) {
   return new RemoteObjects(options);
 };
 
-RemoteObjects.extend = function (exports) {
+RemoteObjects.extend = function(exports) {
   return new ExportsHelper(exports);
 };
 
@@ -68,12 +68,12 @@ RemoteObjects.extend = function (exports) {
  * @return {Function}
  */
 
-RemoteObjects.prototype.handler = function (name, options) {
+RemoteObjects.prototype.handler = function(name, options) {
   var Adapter = this.adapter(name);
   var adapter = new Adapter(this, options);
   var handler = adapter.createHandler();
-  
-  if(handler) {
+
+  if (handler) {
     // allow adapter reference from handler
     handler.adapter = adapter;
   }
@@ -100,7 +100,7 @@ RemoteObjects.prototype.connect = function(url, name) {
  *
  * @param {String} method The remote method string
  * @param {String} [ctorArgs] Constructor arguments (for prototype methods)
- * @param {String} [args] Method arguments 
+ * @param {String} [args] Method arguments
  * @callback {Function} [callback] callback
  * @param {Error} err
  * @param {Any} arg...
@@ -119,7 +119,7 @@ RemoteObjects.prototype.invoke = function(method, ctorArgs, args, callback) {
  * @return {Adapter}
  */
 
-RemoteObjects.prototype.adapter = function (name) {
+RemoteObjects.prototype.adapter = function(name) {
   return require('./' + name + '-adapter');
 };
 
@@ -127,7 +127,7 @@ RemoteObjects.prototype.adapter = function (name) {
  * Get all classes.
  */
 
-RemoteObjects.prototype.classes = function (options) {
+RemoteObjects.prototype.classes = function(options) {
   options = options || {};
   var exports = this.exports;
   var result = [];
@@ -135,13 +135,13 @@ RemoteObjects.prototype.classes = function (options) {
 
   Object
     .keys(exports)
-    .forEach(function (name) {
+    .forEach(function(name) {
       result.push(new SharedClass(name, exports[name], options));
     });
 
   Object
     .keys(sharedClasses)
-    .forEach(function (name) {
+    .forEach(function(name) {
       result.push(sharedClasses[name]);
     });
 
@@ -154,7 +154,7 @@ RemoteObjects.prototype.classes = function (options) {
  * @param {SharedClass} sharedClass
  */
 
-RemoteObjects.prototype.addClass = function (sharedClass) {
+RemoteObjects.prototype.addClass = function(sharedClass) {
   assert(sharedClass instanceof SharedClass);
   this._classes[sharedClass.name] = sharedClass;
 };
@@ -171,11 +171,11 @@ RemoteObjects.prototype.addClass = function (sharedClass) {
  * @param {String} methodString
  */
 
-RemoteObjects.prototype.findMethod = function (methodString) {
+RemoteObjects.prototype.findMethod = function(methodString) {
   var methods = this.methods();
 
   for (var i = 0; i < methods.length; i++) {
-    if(methods[i].stringName === methodString) return methods[i];
+    if (methods[i].stringName === methodString) return methods[i];
   }
 };
 
@@ -183,12 +183,12 @@ RemoteObjects.prototype.findMethod = function (methodString) {
  * List all methods.
  */
 
-RemoteObjects.prototype.methods = function () {
+RemoteObjects.prototype.methods = function() {
   var methods = [];
 
   this
     .classes()
-    .forEach(function (sc) {
+    .forEach(function(sc) {
       methods = sc.methods().concat(methods);
     });
 
@@ -199,11 +199,11 @@ RemoteObjects.prototype.methods = function () {
  * Get as JSON.
  */
 
-RemoteObjects.prototype.toJSON = function () {
+RemoteObjects.prototype.toJSON = function() {
   var result = {};
   var methods = this.methods();
 
-  methods.forEach(function (sharedMethod) {
+  methods.forEach(function(sharedMethod) {
     result[sharedMethod.stringName] = {
       http: sharedMethod.fn && sharedMethod.fn.http,
       accepts: sharedMethod.accepts,
@@ -222,8 +222,8 @@ RemoteObjects.prototype.toJSON = function () {
  *
  * ```js
  * // Do something before our `user.greet` example, earlier.
- * remotes.before('user.greet', function (ctx, next) {
- *   if((ctx.req.param('password') || '').toString() !== '1234') {
+ * remotes.before('user.greet', function(ctx, next) {
+ *   if ((ctx.req.param('password') || '').toString() !== '1234') {
  *     next(new Error('Bad password!'));
  *   } else {
  *     next();
@@ -231,13 +231,13 @@ RemoteObjects.prototype.toJSON = function () {
  * });
  *
  * // Do something before any `user` method.
- * remotes.before('user.*', function (ctx, next) {
+ * remotes.before('user.*', function(ctx, next) {
  *   console.log('Calling a user method.');
  *   next();
  * });
  *
  * // Do something before a `dog` instance method.
- * remotes.before('dog.prototype.*', function (ctx, next) {
+ * remotes.before('dog.prototype.*', function(ctx, next) {
  *   var dog = this;
  *   console.log('Calling a method on "%s".', dog.name);
  *   next();
@@ -251,7 +251,7 @@ RemoteObjects.prototype.toJSON = function () {
  * @param {SharedMethod} method The SharedMethod object
  */
 
-RemoteObjects.prototype.before = function (methodMatch, fn) {
+RemoteObjects.prototype.before = function(methodMatch, fn) {
   this.on('before.' + methodMatch, fn);
 };
 
@@ -263,19 +263,19 @@ RemoteObjects.prototype.before = function (methodMatch, fn) {
  * ```js
  * // Do something after the `speak` instance method.
  * // NOTE: you cannot cancel a method after it has been called.
- * remotes.after('dog.prototype.speak', function (ctx, next) {
+ * remotes.after('dog.prototype.speak', function(ctx, next) {
  *   console.log('After speak!');
  *   next();
  * });
  *
  * // Do something before all methods.
- * remotes.before('**', function (ctx, next, method) {
+ * remotes.before('**', function(ctx, next, method) {
  *   console.log('Calling:', method.name);
  *   next();
  * });
  *
  * // Modify all returned values named `result`.
- * remotes.after('**', function (ctx, next) {
+ * remotes.after('**', function(ctx, next) {
  *   ctx.result += '!!!';
  *   next();
  * });
@@ -288,7 +288,7 @@ RemoteObjects.prototype.before = function (methodMatch, fn) {
  * @param {SharedMethod} method The SharedMethod object
  */
 
-RemoteObjects.prototype.after = function (methodMatch, fn) {
+RemoteObjects.prototype.after = function(methodMatch, fn) {
   this.on('after.' + methodMatch, fn);
 };
 
@@ -311,7 +311,7 @@ RemoteObjects.prototype.execHooks = function(when, method, scope, ctx, next) {
   this.objectName = method.sharedClass.name;
   this.methodName = method.name;
 
-  if(this.wildcard) {
+  if (this.wildcard) {
     handler = [];
     var ns = typeof type === 'string' ? type.split(this.delimiter) : type.slice();
     searchListenerTree.call(this, handler, ns, this.listenerTree, 0);
@@ -329,7 +329,9 @@ RemoteObjects.prototype.execHooks = function(when, method, scope, ctx, next) {
     var l = arguments.length;
     var i;
     var args = new Array(l - 1);
-    for (i = 1; i < l; i++) args[i - 1] = arguments[i];
+    for (i = 1; i < l; i++) {
+      args[i - 1] = arguments[i];
+    }
 
     var listeners = handler.slice();
     for (i = 0, l = listeners.length; i < l; i++) {
@@ -342,11 +344,11 @@ RemoteObjects.prototype.execHooks = function(when, method, scope, ctx, next) {
   }
 
   function execStack(err) {
-    if(err) return next(err);
+    if (err) return next(err);
 
     var cur = stack.shift();
 
-    if(cur) {
+    if (cur) {
       cur.call(scope, ctx, execStack, method);
     } else {
       next();
@@ -361,8 +363,19 @@ function searchListenerTree(handlers, type, tree, i) {
   if (!tree) {
     return [];
   }
-  var listeners=[], leaf, len, branch, xTree, xxTree, isolatedBranch, endReached,
-      typeLength = type.length, currentType = type[i], nextType = type[i+1];
+
+  var listeners = [];
+  var leaf;
+  var len;
+  var branch;
+  var xTree;
+  var xxTree;
+  var isolatedBranch;
+  var endReached;
+  var typeLength = type.length;
+  var currentType = type[i];
+  var nextType = type[i + 1];
+
   if (i === typeLength && tree._listeners) {
     //
     // If at the end of the event(s) list and the tree has listeners
@@ -388,13 +401,13 @@ function searchListenerTree(handlers, type, tree, i) {
       for (branch in tree) {
         if (branch !== '_listeners' && tree.hasOwnProperty(branch)) {
           listeners = listeners.concat(
-            searchListenerTree(handlers, type, tree[branch], i+1));
+            searchListenerTree(handlers, type, tree[branch], i + 1));
         }
       }
       return listeners;
-    } else if(currentType === '**') {
-      endReached = (i+1 === typeLength || (i+2 === typeLength && nextType === '*'));
-      if(endReached && tree._listeners) {
+    } else if (currentType === '**') {
+      endReached = (i + 1 === typeLength || (i + 2 === typeLength && nextType === '*'));
+      if (endReached && tree._listeners) {
         // The next element has a _listeners, add it to the handlers.
         listeners = listeners.concat(
           searchListenerTree(handlers, type, tree, typeLength));
@@ -402,16 +415,16 @@ function searchListenerTree(handlers, type, tree, i) {
 
       for (branch in tree) {
         if (branch !== '_listeners' && tree.hasOwnProperty(branch)) {
-          if(branch === '*' || branch === '**') {
-            if(tree[branch]._listeners && !endReached) {
+          if (branch === '*' || branch === '**') {
+            if (tree[branch]._listeners && !endReached) {
               listeners = listeners.concat(
                 searchListenerTree(handlers, type, tree[branch], typeLength));
             }
             listeners = listeners.concat(
               searchListenerTree(handlers, type, tree[branch], i));
-          } else if(branch === nextType) {
+          } else if (branch === nextType) {
             listeners = listeners.concat(
-              searchListenerTree(handlers, type, tree[branch], i+2));
+              searchListenerTree(handlers, type, tree[branch], i + 2));
           } else {
             // No match on this one, shift into the tree but not in the type array.
             listeners = listeners.concat(
@@ -423,7 +436,7 @@ function searchListenerTree(handlers, type, tree, i) {
     }
 
     listeners = listeners.concat(
-      searchListenerTree(handlers, type, tree[currentType], i+1));
+      searchListenerTree(handlers, type, tree[currentType], i + 1));
   }
 
   xTree = tree['*'];
@@ -432,37 +445,37 @@ function searchListenerTree(handlers, type, tree, i) {
     // If the listener tree will allow any match for this part,
     // then recursively explore all branches of the tree
     //
-    searchListenerTree(handlers, type, xTree, i+1);
+    searchListenerTree(handlers, type, xTree, i + 1);
   }
 
   xxTree = tree['**'];
-  if(xxTree) {
-    if(i < typeLength) {
-      if(xxTree._listeners) {
+  if (xxTree) {
+    if (i < typeLength) {
+      if (xxTree._listeners) {
         // If we have a listener on a '**', it will catch all, so add its handler.
         searchListenerTree(handlers, type, xxTree, typeLength);
       }
 
       // Build arrays of matching next branches and others.
-      for(branch in xxTree) {
-        if(branch !== '_listeners' && xxTree.hasOwnProperty(branch)) {
-          if(branch === nextType) {
+      for (branch in xxTree) {
+        if (branch !== '_listeners' && xxTree.hasOwnProperty(branch)) {
+          if (branch === nextType) {
             // We know the next element will match, so jump twice.
-            searchListenerTree(handlers, type, xxTree[branch], i+2);
-          } else if(branch === currentType) {
+            searchListenerTree(handlers, type, xxTree[branch], i + 2);
+          } else if (branch === currentType) {
             // Current node matches, move into the tree.
-            searchListenerTree(handlers, type, xxTree[branch], i+1);
+            searchListenerTree(handlers, type, xxTree[branch], i + 1);
           } else {
             isolatedBranch = {};
             isolatedBranch[branch] = xxTree[branch];
-            searchListenerTree(handlers, type, { '**': isolatedBranch }, i+1);
+            searchListenerTree(handlers, type, { '**': isolatedBranch }, i + 1);
           }
         }
       }
-    } else if(xxTree._listeners) {
+    } else if (xxTree._listeners) {
       // We have reached the end and still on a '**'
       searchListenerTree(handlers, type, xxTree, typeLength);
-    } else if(xxTree['*'] && xxTree['*']._listeners) {
+    } else if (xxTree['*'] && xxTree['*']._listeners) {
       searchListenerTree(handlers, type, xxTree['*'], typeLength);
     }
   }
@@ -473,9 +486,9 @@ function searchListenerTree(handlers, type, tree, i) {
 /**
  * Invoke the given shared method using the supplied context.
  * Execute registered before/after hooks.
- * @param ctx
- * @param method
- * @param cb
+ * @param {Object} ctx
+ * @param {Object} method
+ * @param {function(Error=)} cb
  */
 RemoteObjects.prototype.invokeMethodInContext = function(ctx, method, cb) {
   var self = this;
@@ -515,7 +528,7 @@ RemoteObjects.prototype.getScope = function(ctx, method) {
  * ```js
  * remotes.defineType('MyType', function(val, ctx) {
  *   // use the val and ctx objects to return the concrete value
- *   return new MyType(val); 
+ *   return new MyType(val);
  * });
  * ```
  *
@@ -524,7 +537,7 @@ RemoteObjects.prototype.getScope = function(ctx, method) {
  * @param {String} name The type name
  * @param {Function} converter
  */
- 
+
 RemoteObjects.defineType =
 RemoteObjects.convert =
 RemoteObjects.prototype.defineType =

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -11,17 +11,17 @@ RestAdapter.RestMethod = RestMethod;
  * Module dependencies.
  */
 
-var EventEmitter = require('events').EventEmitter
-  , debug = require('debug')('strong-remoting:rest-adapter')
-  , util = require('util')
-  , inherits = util.inherits
-  , assert = require('assert')
-  , express = require('express')
-  , bodyParser = require('body-parser')
-  , cors = require('cors')
-  , async = require('async')
-  , HttpInvocation = require('./http-invocation')
-  , HttpContext = require('./http-context');
+var EventEmitter = require('events').EventEmitter;
+var debug = require('debug')('strong-remoting:rest-adapter');
+var util = require('util');
+var inherits = util.inherits;
+var assert = require('assert');
+var express = require('express');
+var bodyParser = require('body-parser');
+var cors = require('cors');
+var async = require('async');
+var HttpInvocation = require('./http-invocation');
+var HttpContext = require('./http-context');
 
 var json = bodyParser.json;
 var urlencoded = bodyParser.urlencoded;
@@ -51,7 +51,7 @@ inherits(RestAdapter, EventEmitter);
  */
 
 RestAdapter.create =
-RestAdapter.createRestAdapter = function (remotes) {
+RestAdapter.createRestAdapter = function(remotes) {
   // add simplified construction / sugar here
   return new RestAdapter(remotes);
 };
@@ -64,19 +64,19 @@ RestAdapter.prototype.getRoutes = getRoutes;
 function getRoutes(obj) {
   var routes = obj.http;
 
-  if(routes && !Array.isArray(routes)) {
+  if (routes && !Array.isArray(routes)) {
     routes = [routes];
   }
 
   // overidden
-  if(routes) {
+  if (routes) {
     // patch missing verbs / routes
-    routes.forEach(function (r) {
+    routes.forEach(function(r) {
       r.verb = String(r.verb || 'all').toLowerCase();
       r.path = r.path || ('/' + obj.name);
     });
   } else {
-    if(obj.name === 'sharedCtor') {
+    if (obj.name === 'sharedCtor') {
       routes = [{
         verb: 'all',
         path: '/prototype'
@@ -118,11 +118,11 @@ RestAdapter.prototype.invoke = function(method, ctorArgs, args, callback) {
 
 RestAdapter.prototype.getRestMethodByName = function(name) {
   var classes = this.getClasses();
-  for(var i = 0; i < classes.length; i++) {
+  for (var i = 0; i < classes.length; i++) {
     var restClass = classes[i];
-    for(var j = 0; j < restClass.methods.length; j++) {
+    for (var j = 0; j < restClass.methods.length; j++) {
       var restMethod = restClass.methods[j];
-      if(restMethod.fullName === name) {
+      if (restMethod.fullName === name) {
         return restMethod;
       }
     }
@@ -191,15 +191,15 @@ function sortRoutes(r1, r2) {
 
 RestAdapter.sortRoutes = sortRoutes; // For testing
 
-RestAdapter.prototype.createHandler = function () {
+RestAdapter.prototype.createHandler = function() {
   var root = express.Router();
   var adapter = this;
   var classes = this.getClasses();
 
   // Add a handler to tolerate empty json as connect's json middleware throws an error
   root.use(function(req, res, next) {
-    if(req.is('application/json')) {
-      if(req.get('Content-Length') === '0') {
+    if (req.is('application/json')) {
+      if (req.get('Content-Length') === '0') {
         // This doesn't cover the transfer-encoding: chunked
         req._body = true; // Mark it as parsed
         req.body = {};
@@ -236,7 +236,7 @@ RestAdapter.prototype.createHandler = function () {
 
   var handleUnknownPaths = this._shouldHandleUnknownPaths();
 
-  classes.forEach(function (restClass) {
+  classes.forEach(function(restClass) {
     var router = express.Router();
     var className = restClass.sharedClass.name;
 
@@ -270,7 +270,7 @@ RestAdapter.prototype.createHandler = function () {
     // Mount the remoteClass router on all class routes.
     restClass
       .routes
-      .forEach(function (route) {
+      .forEach(function(route) {
         debug('    at %s', route.path);
         root.use(route.path, router);
       });
@@ -320,7 +320,7 @@ RestAdapter.errorHandler = function(options) {
     if (typeof options.handler === 'function') {
       try {
         options.handler(err, req, res, defaultHandler);
-      } catch(e) {
+      } catch (e) {
         defaultHandler(e);
       }
     } else {
@@ -328,12 +328,12 @@ RestAdapter.errorHandler = function(options) {
     }
 
     function defaultHandler(handlerError) {
-      if(handlerError) {
+      if (handlerError) {
         // ensure errors that occurred during
         // the handler are reported
         err = handlerError;
       }
-      if(typeof err === 'string') {
+      if (typeof err === 'string') {
         err = new Error(err);
         err.status = err.statusCode = 500;
       }
@@ -369,7 +369,7 @@ RestAdapter.prototype._registerMethodRouteHandlers = function(router,
 
   debug('        %s %s %s', route.verb, route.path, handler.name);
   var verb = route.verb;
-  if(verb === 'del') {
+  if (verb === 'del') {
     // Express 4.x only supports delete
     verb = 'delete';
   }
@@ -434,27 +434,27 @@ RestAdapter.prototype._invokeMethod = function(ctx, method, next) {
   );
 };
 
-RestAdapter.prototype.allRoutes = function () {
+RestAdapter.prototype.allRoutes = function() {
   var routes = [];
   var adapter = this;
   var classes = this.remotes.classes(this.options);
   var currentRoot = '';
 
-  classes.forEach(function (sc) {
+  classes.forEach(function(sc) {
     adapter
       .getRoutes(sc)
-      .forEach(function (classRoute) {
+      .forEach(function(classRoute) {
         currentRoot = classRoute.path;
         var methods = sc.methods();
 
-        methods.forEach(function (method) {
-          adapter.getRoutes(method).forEach(function (route) {
-            if(method.isStatic) {
+        methods.forEach(function(method) {
+          adapter.getRoutes(method).forEach(function(route) {
+            if (method.isStatic) {
               addRoute(route.verb, route.path, method);
             } else {
               adapter
                 .getRoutes(method.sharedCtor)
-                .forEach(function (sharedCtorRoute) {
+                .forEach(function(sharedCtorRoute) {
                   addRoute(route.verb, sharedCtorRoute.path + route.path, method);
                 });
             }
@@ -465,15 +465,14 @@ RestAdapter.prototype.allRoutes = function () {
 
   return routes;
 
-
   function addRoute(verb, path, method) {
-    if(path === '/' || path === '//') {
+    if (path === '/' || path === '//') {
       path = currentRoot;
     } else {
       path = currentRoot + path;
     }
 
-    if(path[path.length - 1] === '/') {
+    if (path[path.length - 1] === '/') {
       path = path.substr(0, path.length - 1);
     }
 
@@ -607,7 +606,7 @@ function joinPaths(left, right) {
   if (!left) return right;
   if (!right || right == '/') return left;
 
-  var glue = left[left.length-1] + right[0];
+  var glue = left[left.length - 1] + right[0];
   if (glue == '//')
     return left + right.slice(1);
   else if (glue[0] == '/' || glue[1] == '/')

--- a/lib/shared-class.js
+++ b/lib/shared-class.js
@@ -8,13 +8,13 @@ module.exports = SharedClass;
  * Module dependencies.
  */
 
-var debug = require('debug')('strong-remoting:shared-class')
-  , util = require('util')
-  , inherits = util.inherits
-  , inflection = require('inflection')
-  , SharedMethod = require('./shared-method')
-  , assert = require('assert');
-  
+var debug = require('debug')('strong-remoting:shared-class');
+var util = require('util');
+var inherits = util.inherits;
+var inflection = require('inflection');
+var SharedMethod = require('./shared-method');
+var assert = require('assert');
+
 /**
  * Create a new `SharedClass` with the given `options`.
  *
@@ -36,14 +36,14 @@ function SharedClass(name, ctor, options) {
   this._disabledMethods = {};
   var http = ctor && ctor.http;
   var normalize = options.normalizeHttpPath;
-  
+
   var defaultHttp = {};
   defaultHttp.path = '/' + this.name;
 
-  if(Array.isArray(http)) {
+  if (Array.isArray(http)) {
     // use array as is
     this.http = http;
-    if(http.length === 0) {
+    if (http.length === 0) {
       http.push(defaultHttp);
     }
     if (normalize) {
@@ -58,7 +58,7 @@ function SharedClass(name, ctor, options) {
     this.http = util._extend(defaultHttp, http);
     if (normalize) this.http.path = SharedClass.normalizeHttpPath(this.http.path);
   }
-  
+
   if (typeof ctor === 'function' && ctor.sharedCtor) {
     // TODO(schoon) - Can we fall back to using the ctor as a method directly?
     // Without that, all remote methods have to be two levels deep, e.g.
@@ -87,15 +87,15 @@ SharedClass.normalizeHttpPath = function(path) {
  * @returns {SharedMethod[]} An array of shared methods
  */
 
-SharedClass.prototype.methods = function () {
+SharedClass.prototype.methods = function() {
   var ctor = this.ctor;
   var methods = [];
   var sc = this;
   var functionIndex = [];
 
   // static methods
-  eachRemoteFunctionInObject(ctor, function (fn, name) {
-    if(functionIndex.indexOf(fn) === -1) {
+  eachRemoteFunctionInObject(ctor, function(fn, name) {
+    if (functionIndex.indexOf(fn) === -1) {
       functionIndex.push(fn);
     } else {
       var sharedMethod = find(methods, fn);
@@ -104,10 +104,10 @@ SharedClass.prototype.methods = function () {
     }
     methods.push(SharedMethod.fromFunction(fn, name, sc, true));
   });
-  
+
   // instance methods
-  eachRemoteFunctionInObject(ctor.prototype, function (fn, name) {
-    if(functionIndex.indexOf(fn) === -1) {
+  eachRemoteFunctionInObject(ctor.prototype, function(fn, name) {
+    if (functionIndex.indexOf(fn) === -1) {
       functionIndex.push(fn);
     } else {
       var sharedMethod = find(methods, fn);
@@ -121,18 +121,18 @@ SharedClass.prototype.methods = function () {
   this._resolvers.forEach(function(resolver) {
     resolver.call(this, _define.bind(sc, methods));
   });
-  
+
   methods = methods.concat(this._methods);
 
   return methods.filter(sc.isMethodEnabled.bind(sc));
 };
 
 SharedClass.prototype.isMethodEnabled = function(sharedMethod) {
-  if(!sharedMethod.shared) return false;
-  
+  if (!sharedMethod.shared) return false;
+
   var key = this.getKeyFromMethodNameAndTarget(sharedMethod.name, sharedMethod.isStatic);
 
-  if(this._disabledMethods.hasOwnProperty(key)) {
+  if (this._disabledMethods.hasOwnProperty(key)) {
     return false;
   }
 
@@ -221,26 +221,26 @@ SharedClass.prototype.getKeyFromMethodNameAndTarget = function(name, isStatic) {
 };
 
 function find(methods, fn, isStatic) {
-  for(var i = 0; i < methods.length; i++) {
+  for (var i = 0; i < methods.length; i++) {
     var method = methods[i];
-    if(method.isDelegateFor(fn, isStatic)) return method;
+    if (method.isDelegateFor(fn, isStatic)) return method;
   }
   return null;
 }
 
 function eachRemoteFunctionInObject(obj, f) {
-  if(!obj) return;
-    
-  for(var key in obj) {
-    if(key === 'super_') {
+  if (!obj) return;
+
+  for (var key in obj) {
+    if (key === 'super_') {
       // Skip super class
       continue;
     }
     var fn;
-     
+
     try {
       fn = obj[key];
-    } catch(e) {
+    } catch (e) {
     }
 
     // HACK: [rfeng] Do not expose model constructors
@@ -248,7 +248,7 @@ function eachRemoteFunctionInObject(obj, f) {
     // User.email = Email;
     // User.accessToken = AccessToken;
     // Both Email and AccessToken can have shared flag set to true
-    if(typeof fn === 'function' && fn.shared && !fn.modelName) {
+    if (typeof fn === 'function' && fn.shared && !fn.modelName) {
       f(fn, key);
     }
   }

--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -8,10 +8,10 @@ module.exports = SharedMethod;
  * Module dependencies.
  */
 
-var debug = require('debug')('strong-remoting:shared-method')
-  , util = require('util')
-  , traverse = require('traverse')
-  , assert = require('assert');
+var debug = require('debug')('strong-remoting:shared-method');
+var util = require('util');
+var traverse = require('traverse');
+var assert = require('assert');
 
 /**
  * Create a new `SharedMethod` with the given `fn`.
@@ -32,7 +32,7 @@ var debug = require('debug')('strong-remoting:shared-method')
  * @param {String} [options.accepts.http] HTTP mapping for the argument
  * @param {String} [options.accepts.http.source] The HTTP source for the
  * argument. May be one of the following:
- * 
+ *
  * - `req` - the Express `Request` object
  * - `req` - the Express `Request` object
  * - `body` - the `req.body` value
@@ -65,7 +65,7 @@ function SharedMethod(fn, name, sc, options) {
   if (typeof options === 'boolean') {
     options = { isStatic: options };
   }
-  
+
   this.fn = fn;
   fn = fn || {};
   this.name = name;
@@ -82,29 +82,29 @@ function SharedMethod(fn, name, sc, options) {
   this.http = options.http || fn.http || {};
   this.rest = options.rest || fn.rest || {};
   this.shared = options.shared;
-  if(this.shared === undefined) {
+  if (this.shared === undefined) {
     this.shared = true;
   }
-  if(fn.shared === false) {
+  if (fn.shared === false) {
     this.shared = false;
   }
   this.sharedClass = sc;
 
-  if(sc) {
+  if (sc) {
     this.ctor = sc.ctor;
     this.sharedCtor = sc.sharedCtor;
   }
-  if(name === 'sharedCtor') {
+  if (name === 'sharedCtor') {
     this.isSharedCtor = true;
   }
 
-  if(this.accepts && !Array.isArray(this.accepts)) {
+  if (this.accepts && !Array.isArray(this.accepts)) {
     this.accepts = [this.accepts];
   }
-  if(this.returns && !Array.isArray(this.returns)) {
+  if (this.returns && !Array.isArray(this.returns)) {
     this.returns = [this.returns];
   }
-  if(this.errors && !Array.isArray(this.errors)) {
+  if (this.errors && !Array.isArray(this.errors)) {
     this.errors = [this.errors];
   }
 
@@ -141,7 +141,7 @@ SharedMethod.fromFunction = function(fn, name, sharedClass, isStatic) {
  * @param {Function} fn callback `fn(err, result)` containing named result data
  */
 
-SharedMethod.prototype.invoke = function (scope, args, fn) {
+SharedMethod.prototype.invoke = function(scope, args, fn) {
   var accepts = this.accepts;
   var returns = this.returns;
   var errors = this.errors;
@@ -151,8 +151,8 @@ SharedMethod.prototype.invoke = function (scope, args, fn) {
   var result;
 
   // map the given arg data in order they are expected in
-  if(accepts) {
-    for(var i = 0; i < accepts.length; i++) {
+  if (accepts) {
+    for (var i = 0; i < accepts.length; i++) {
       var desc = accepts[i];
       var name = desc.name || desc.arg;
       var uarg = SharedMethod.convertArg(desc, args[name]);
@@ -160,8 +160,8 @@ SharedMethod.prototype.invoke = function (scope, args, fn) {
 
       // is the arg optional?
       // arg was not provided
-      if(actualType === 'undefined') {
-        if(desc.required) {
+      if (actualType === 'undefined') {
+        if (desc.required) {
           var err = new Error(name + ' is a required arg');
           err.statusCode = 400;
           return fn(err);
@@ -173,8 +173,8 @@ SharedMethod.prototype.invoke = function (scope, args, fn) {
       }
 
       // convert strings
-      if(actualType === 'string' && desc.type !== 'any' && actualType !== desc.type) {
-        switch(desc.type) {
+      if (actualType === 'string' && desc.type !== 'any' && actualType !== desc.type) {
+        switch (desc.type) {
           case 'string':
             break;
           case 'date':
@@ -191,7 +191,7 @@ SharedMethod.prototype.invoke = function (scope, args, fn) {
           default:
             try {
               uarg = JSON.parse(uarg);
-            } catch(err) {
+            } catch (err) {
               debug('- %s - invalid value for argument \'%s\' of type \'%s\': %s',
                 sharedMethod.name, name, desc.type, uarg);
               return fn(err);
@@ -207,7 +207,7 @@ SharedMethod.prototype.invoke = function (scope, args, fn) {
 
   // define the callback
   function callback(err) {
-    if(err) {
+    if (err) {
       return fn(err);
     }
 
@@ -238,7 +238,7 @@ SharedMethod.prototype.invoke = function (scope, args, fn) {
  * @returns {String} The type name
  */
 
-SharedMethod.getType = function (val) {
+SharedMethod.getType = function(val) {
   var type = typeof val;
 
   switch (type) {
@@ -280,21 +280,21 @@ SharedMethod.getType = function (val) {
  */
 
 SharedMethod.convertArg = function(accept, raw) {
-  if(accept.http && (accept.http.source === 'req' ||
+  if (accept.http && (accept.http.source === 'req' ||
     accept.http.source === 'res' ||
     accept.http.source === 'context'
     )) {
     return raw;
   }
-  if(raw === null || typeof raw !== 'object') {
+  if (raw === null || typeof raw !== 'object') {
     return raw;
   }
   var data = traverse(raw).forEach(function(x) {
-    if(x === null || typeof x !== 'object') {
+    if (x === null || typeof x !== 'object') {
       return x;
     }
     var result = x;
-    if(x.$type === 'base64' || x.$type === 'date') {
+    if (x.$type === 'base64' || x.$type === 'date') {
       switch (x.$type) {
         case 'base64':
           result = new Buffer(x.$data, 'base64');
@@ -322,7 +322,7 @@ SharedMethod.toResult = function(returns, raw) {
     return;
   }
 
-  returns = returns.filter(function (item, index) {
+  returns = returns.filter(function(item, index) {
     if (index >= raw.length) {
       return false;
     }
@@ -335,7 +335,7 @@ SharedMethod.toResult = function(returns, raw) {
     return true;
   });
 
-  returns.forEach(function (item, index) {
+  returns.forEach(function(item, index) {
     result[item.name || item.arg] = convert(raw[index]);
   });
 
@@ -359,17 +359,16 @@ SharedMethod.toResult = function(returns, raw) {
   }
 };
 
-
 /**
  * Get the function the `SharedMethod` will `invoke()`.
  */
 
 SharedMethod.prototype.getFunction = function() {
   var fn;
-  
-  if(!this.ctor) return this.fn;
 
-  if(this.isStatic) {
+  if (!this.ctor) return this.fn;
+
+  if (this.isStatic) {
     fn = this.ctor[this.name];
   } else {
     fn = this.ctor.prototype[this.name];
@@ -385,7 +384,7 @@ SharedMethod.prototype.getFunction = function() {
  * // examples
  * sharedMethod.isDelegateFor(myClass.myMethod); // pass a function
  * sharedMethod.isDelegateFor(myClass.prototype.myInstMethod);
- * sharedMethod.isDelegateFor('myMethod', true); // check for a static method by name 
+ * sharedMethod.isDelegateFor('myMethod', true); // check for a static method by name
  * sharedMethod.isDelegateFor('myInstMethod', false); // instance method by name
  * ```
  *
@@ -397,13 +396,12 @@ SharedMethod.prototype.isDelegateFor = function(suspect, isStatic) {
   var type = typeof suspect;
   isStatic = isStatic || false;
 
-
-  if(suspect) {
-    switch(type) {
+  if (suspect) {
+    switch (type) {
       case 'function':
         return this.getFunction() === suspect;
       case 'string':
-        if(this.isStatic !== isStatic) return false;
+        if (this.isStatic !== isStatic) return false;
         return this.name === suspect || this.aliases.indexOf(suspect) !== -1;
     }
   }
@@ -413,12 +411,12 @@ SharedMethod.prototype.isDelegateFor = function(suspect, isStatic) {
 
 /**
  * Add an alias
- * 
+ *
  * @param {String} alias
  */
 
 SharedMethod.prototype.addAlias = function(alias) {
-  if(this.aliases.indexOf(alias) === -1) {
+  if (this.aliases.indexOf(alias) === -1) {
     this.aliases.push(alias);
   }
 };

--- a/lib/socket-io-adapter.js
+++ b/lib/socket-io-adapter.js
@@ -7,15 +7,15 @@ module.exports = SocketIOAdapter;
 /**
  * Module dependencies.
  */
- 
-var EventEmitter = require('events').EventEmitter
-  , debug = require('debug')('strong-remoting:socket-io-adapter')
-  , util = require('util')
-  , inherits = util.inherits
-  , assert = require('assert')
-  , express = require('express')
-  , SocketIOContext = require('./socket-io-context');
-  
+
+var EventEmitter = require('events').EventEmitter;
+var debug = require('debug')('strong-remoting:socket-io-adapter');
+var util = require('util');
+var inherits = util.inherits;
+var assert = require('assert');
+var express = require('express');
+var SocketIOContext = require('./socket-io-context');
+
 /**
  * Create a new `RestAdapter` with the given `options`.
  *
@@ -25,11 +25,11 @@ var EventEmitter = require('events').EventEmitter
 
 function SocketIOAdapter(remotes, server) {
   EventEmitter.apply(this, arguments);
-  
+
   // throw an error if args are not supplied
   // assert(typeof options === 'object',
   //   'RestAdapter requires an options object');
-  
+
   this.remotes = remotes;
   this.server = server;
   this.Context = SocketIOContext;
@@ -45,27 +45,27 @@ inherits(SocketIOAdapter, EventEmitter);
  * Simplified APIs
  */
 
-SocketIOAdapter.create = function (remotes) {
+SocketIOAdapter.create = function(remotes) {
   // add simplified construction / sugar here
   return new SocketIOAdapter(remotes);
 };
 
-SocketIOAdapter.prototype.createHandler = function () {
+SocketIOAdapter.prototype.createHandler = function() {
   var adapter = this;
   var remotes = this.remotes;
   var Context = this.Context;
   var classes = this.remotes.classes();
   var io = require('socket.io').listen(this.server);
 
-  io.sockets.on('connection', function (socket) {
-    socket.on('invoke', function (methodString, ctorArgs, args, id) {
+  io.sockets.on('connection', function(socket) {
+    socket.on('invoke', function(methodString, ctorArgs, args, id) {
       var method = remotes.findMethod(methodString);
-      
-      if(method) {
+
+      if (method) {
         // create context NEED ARGS
         var ctx = new Context(socket.request, ctorArgs, args);
-      
-        adapter.invoke(ctx, method, args, function (err, result) {
+
+        adapter.invoke(ctx, method, args, function(err, result) {
           socket.emit('result', {
             data: result,
             id: id,
@@ -84,18 +84,18 @@ SocketIOAdapter.prototype.createHandler = function () {
   });
 };
 
-SocketIOAdapter.prototype.invoke = function (ctx, method, args, callback) {
+SocketIOAdapter.prototype.invoke = function(ctx, method, args, callback) {
   var remotes = this.remotes;
-  
-  if(method.isStatic) {
-    remotes.execHooks('before', method, method.ctor, ctx, function (err) {
-      if(err) return callback(err);
-    
+
+  if (method.isStatic) {
+    remotes.execHooks('before', method, method.ctor, ctx, function(err) {
+      if (err) return callback(err);
+
       // invoke the static method on the actual constructor
-      ctx.invoke(method.ctor, method, function (err, result) {
-        if(err) return callback(err);
+      ctx.invoke(method.ctor, method, function(err, result) {
+        if (err) return callback(err);
         ctx.result = result;
-        remotes.execHooks('after', method, method.ctor, ctx, function (err) {
+        remotes.execHooks('after', method, method.ctor, ctx, function(err) {
           // send the result
           callback(err, ctx.result);
         });
@@ -103,18 +103,18 @@ SocketIOAdapter.prototype.invoke = function (ctx, method, args, callback) {
     });
   } else {
     // invoke the shared constructor to get an instance
-    ctx.invoke(method, method.sharedCtor, function (err, inst) {
-      if(err) return callback(err);
-      remotes.execHooks('before', method, inst, ctx, function (err) {
-        if(err) {
+    ctx.invoke(method, method.sharedCtor, function(err, inst) {
+      if (err) return callback(err);
+      remotes.execHooks('before', method, inst, ctx, function(err) {
+        if (err) {
           callback(err);
         } else {
           // invoke the instance method
-          ctx.invoke(inst, method, function (err, result) {
-            if(err) return callback(err);
-          
+          ctx.invoke(inst, method, function(err, result) {
+            if (err) return callback(err);
+
             ctx.result = result;
-            remotes.execHooks('after', method, inst, ctx, function (err) {
+            remotes.execHooks('after', method, inst, ctx, function(err) {
               // send the result
               callback(err, ctx.result);
             });

--- a/lib/socket-io-context.js
+++ b/lib/socket-io-context.js
@@ -7,13 +7,13 @@ module.exports = SocketIOContext;
 /**
  * Module dependencies.
  */
- 
-var EventEmitter = require('events').EventEmitter
-  , debug = require('debug')('strong-remoting:socket-io-context')
-  , util = require('util')
-  , inherits = util.inherits
-  , assert = require('assert');
-  
+
+var EventEmitter = require('events').EventEmitter;
+var debug = require('debug')('strong-remoting:socket-io-context');
+var util = require('util');
+var inherits = util.inherits;
+var assert = require('assert');
+
 /**
  * Create a new `SocketIOContext` with the given `options`.
  *
@@ -40,7 +40,7 @@ inherits(SocketIOContext, EventEmitter);
  * @param {Object} options **optional**
  */
 
-SocketIOContext.prototype.getArgByName = function (name, options) {
+SocketIOContext.prototype.getArgByName = function(name, options) {
   return this.args[name];
 };
 
@@ -51,7 +51,7 @@ SocketIOContext.prototype.getArgByName = function (name, options) {
  * @param {Object} options **optional**
  */
 
-SocketIOContext.prototype.setArgByName = function (name, options) {
+SocketIOContext.prototype.setArgByName = function(name, options) {
   throw 'not implemented';
 };
 
@@ -62,7 +62,7 @@ SocketIOContext.prototype.setArgByName = function (name, options) {
  * @param {Object} options **optional**
  */
 
-SocketIOContext.prototype.setResultByName = function (name, options) {
+SocketIOContext.prototype.setResultByName = function(name, options) {
 
 };
 
@@ -73,7 +73,7 @@ SocketIOContext.prototype.setResultByName = function (name, options) {
  * @param {Object} options **optional**
  */
 
-SocketIOContext.prototype.getResultByName = function (name, options) {
+SocketIOContext.prototype.getResultByName = function(name, options) {
 
 };
 
@@ -82,32 +82,32 @@ SocketIOContext.prototype.getResultByName = function (name, options) {
  * the current context.
  */
 
-SocketIOContext.prototype.invoke = function (scope, method, fn) {
+SocketIOContext.prototype.invoke = function(scope, method, fn) {
   var args = method.isSharedCtor ? this.ctorArgs : this.args;
   var accepts = method.accepts;
   var returns = method.returns;
   var errors = method.errors;
   var result;
-  
+
   // invoke the shared method
-  method.invoke(scope, args, function (err) {
+  method.invoke(scope, args, function(err) {
     var resultArgs = arguments;
 
-    if(method.name === 'on' && method.ctor instanceof EventEmitter) {
+    if (method.name === 'on' && method.ctor instanceof EventEmitter) {
       resultArgs[1] = resultArgs[0];
       err = null;
     }
-    
-    if(err) {
+
+    if (err) {
       return fn(err);
     }
 
     // map the arguments using the returns description
-    if(returns.length > 1) {
+    if (returns.length > 1) {
       // multiple
       result = {};
-      
-      returns.forEach(function (o, i) {
+
+      returns.forEach(function(o, i) {
         // map the name of the arg in the returns desc
         // to the same arg in the callback
         result[o.name || o.arg] = resultArgs[i + 1];
@@ -116,7 +116,7 @@ SocketIOContext.prototype.invoke = function (scope, method, fn) {
       // single or no result...
       result = resultArgs[1];
     }
-    
+
     fn(null, result);
   });
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "version": "2.9.0",
   "scripts": {
-    "pretest": "grunt jshint",
+    "pretest": "grunt jscs jshint",
     "test": "mocha"
   },
   "dependencies": {
@@ -36,6 +36,7 @@
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "~0.5.1",
     "grunt-contrib-watch": "~0.6.1",
+    "grunt-jscs": "^0.8.1",
     "grunt-karma": "~0.9.0",
     "karma": "~0.12.23",
     "karma-browserify": "0.2.1",

--- a/test/e2e/fixtures/user.js
+++ b/test/e2e/fixtures/user.js
@@ -21,7 +21,7 @@ User.sharedCtor.http = [
 var login = User.login = function(credentials, callback) {
   debug('login with credentials: %j', credentials);
   setTimeout(function() {
-    if(!credentials.password) {
+    if (!credentials.password) {
       return callback(new Error('password required'));
     }
     callback(null, {userId: 123});

--- a/test/e2e/smoke.test.js
+++ b/test/e2e/smoke.test.js
@@ -5,9 +5,9 @@ var remotes = require('./fixtures/remotes');
 
 remotes.connect(REMOTE_URL, 'rest');
 
-describe('smoke test', function () {
-  describe('remote.invoke()', function () {
-    it('invokes a remote static method', function (done) {
+describe('smoke test', function() {
+  describe('remote.invoke()', function() {
+    it('invokes a remote static method', function(done) {
       remotes.invoke(
         'User.login',
         [{username: 'joe', password: 'secret'}],

--- a/test/helpers/shared-objects-factory.js
+++ b/test/helpers/shared-objects-factory.js
@@ -36,11 +36,10 @@ exports.createSharedClass =  function createSharedClass(config) {
 
   extend(SharedClass.sharedCtor, {
     shared: true,
-    accepts: [ { arg: 'id', type: 'any', http: { source: 'path' }}],
+    accepts: [{ arg: 'id', type: 'any', http: { source: 'path' }}],
     http: { path: '/:id' },
     returns: { root: true }
   });
 
   return SharedClass;
 };
-

--- a/test/helpers/test-server.js
+++ b/test/helpers/test-server.js
@@ -1,3 +1,3 @@
 module.exports = function(callback) {
-  
+
 };

--- a/test/http-invocation.test.js
+++ b/test/http-invocation.test.js
@@ -6,7 +6,7 @@ var expect = require('chai').expect;
 
 describe('HttpInvocation', function() {
   describe('namedArgs', function() {
-    
+
     function expectNamedArgs(accepts, inputArgs, expectedNamedArgs) {
       var method = givenSharedStaticMethod({
         accepts: accepts
@@ -14,7 +14,7 @@ describe('HttpInvocation', function() {
       var inv = new HttpInvocation(method, null, inputArgs);
       expect(inv.namedArgs).to.deep.equal(expectedNamedArgs);
     }
-    
+
     it('should correctly name a single arg', function() {
       expectNamedArgs(
         [{arg: 'a', type: 'number'}],
@@ -22,7 +22,7 @@ describe('HttpInvocation', function() {
         {a: 1}
       );
     });
-    
+
     it('should correctly name multiple args', function() {
       expectNamedArgs(
         [{arg: 'a', type: 'number'}, {arg: 'str', type: 'string'}],
@@ -30,7 +30,7 @@ describe('HttpInvocation', function() {
         {a: 1, str: 'foo'}
       );
     });
-    
+
     it('should correctly name multiple args when a partial set is provided', function() {
       expectNamedArgs(
         [{arg: 'a', type: 'number'}, {arg: 'str', type: 'string'}],

--- a/test/jsonrpc.test.js
+++ b/test/jsonrpc.test.js
@@ -4,14 +4,14 @@ var express = require('express');
 var request = require('supertest');
 var SharedClass = require('../lib/shared-class');
 
-describe('strong-remoting-jsonrpc', function () {
+describe('strong-remoting-jsonrpc', function() {
   var app;
   var server;
   var objects;
   var remotes;
 
   // setup
-  beforeEach(function () {
+  beforeEach(function() {
     if (server) server.close();
     objects = RemoteObjects.create({json: {limit: '1kb'}});
     remotes = objects.exports;
@@ -27,10 +27,10 @@ describe('strong-remoting-jsonrpc', function () {
       .expect('Content-Type', /json/);
   }
 
-  describe('handlers', function () {
-    describe('jsonrpc', function () {
-      beforeEach(function () {
-        app.use(function (req, res, next) {
+  describe('handlers', function() {
+    describe('jsonrpc', function() {
+      beforeEach(function() {
+        app.use(function(req, res, next) {
           // create the handler for each request
           objects.handler('jsonrpc').apply(objects, arguments);
         });
@@ -45,22 +45,21 @@ describe('strong-remoting-jsonrpc', function () {
         greet.shared = true;
 
         // Create a shared method directly on the function object for named parameters tests
-        function sum(numA,numB,cb){
-          cb(null,numA+numB);
+        function sum(numA, numB, cb) {
+          cb(null, numA + numB);
         }
-        remotes.mathematic={
+        remotes.mathematic = {
           sum:sum
         };
-        sum.accepts=[
-          {'arg':'numA','type':'number'},
-          {'arg':'numB','type':'number'},
+        sum.accepts = [
+          {'arg':'numA', 'type':'number'},
+          {'arg':'numB', 'type':'number'},
         ];
-        sum.returns={
+        sum.returns = {
           'arg':'sum',
           'type':'number'
         };
-        sum.shared=true;
-
+        sum.shared = true;
 
         // Create a shared method using SharedClass/SharedMethod
         function Product() {
@@ -77,20 +76,20 @@ describe('strong-remoting-jsonrpc', function () {
         objects.addClass(productClass);
       });
 
-      it('should support calling object methods', function (done) {
+      it('should support calling object methods', function(done) {
         jsonrpc('/user/jsonrpc', 'greet', ['JS'])
           .expect({'jsonrpc': '2.0', 'id': 1, 'result': 'JS'}, done);
       });
-      it('Should successfully call a method with named parameters',function(done){
-        jsonrpc('/mathematic/jsonrpc', 'sum', {'numB':9,'numA':2})
+      it('Should successfully call a method with named parameters', function(done) {
+        jsonrpc('/mathematic/jsonrpc', 'sum', {'numB': 9, 'numA': 2})
           .expect({'jsonrpc': '2.0', 'id': 1, 'result': 11}, done);
       });
-      it('should support a remote method using shared method', function (done) {
+      it('should support a remote method using shared method', function(done) {
         jsonrpc('/product/jsonrpc', 'getPrice', [])
           .expect({'jsonrpc': '2.0', 'id': 1, 'result': 100}, done);
       });
 
-      it('should report error for non-existent methods', function (done) {
+      it('should report error for non-existent methods', function(done) {
         jsonrpc('/user/jsonrpc', 'greet1', ['JS'])
           .expect({
             'jsonrpc': '2.0',
@@ -103,7 +102,7 @@ describe('strong-remoting-jsonrpc', function () {
       });
 
       // The 1kb limit is set by RemoteObjects.create({json: {limit: '1kb'}});
-      it('should reject json payload larger than 1kb', function (done) {
+      it('should reject json payload larger than 1kb', function(done) {
         // Build an object that is larger than 1kb
         var name = '';
         for (var i = 0; i < 2048; i++) {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,0 +1,91 @@
+// Karma configuration
+// http://karma-runner.github.io/0.12/config/configuration-file.html
+
+module.exports = function(config) {
+  config.set({
+    // base path, that will be used to resolve files and exclude
+    basePath: '../',
+
+    // frameworks to use
+    frameworks: ['mocha', 'browserify'],
+
+    plugins: [
+      'karma-browserify',
+      'karma-mocha',
+      'karma-phantomjs-launcher',
+      'karma-chrome-launcher',
+      'karma-junit-reporter'
+    ],
+
+    // list of files / patterns to load in the browser
+    files: [
+      'test/e2e/fixtures/*.js',
+      'test/e2e/smoke.test.js'
+    ],
+
+    // list of files to exclude
+    exclude: [
+
+    ],
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress', 'junit', 'growl', 'coverage'
+    reporters: ['dots'],
+
+    // web server port
+    port: 9876,
+
+    // cli runner port
+    runnerPort: 9100,
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR ||
+    //    config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: 'warn',
+
+    // enable / disable watching file and executing tests
+    // whenever any file changes
+    autoWatch: true,
+
+    // Start these browsers, currently available:
+    // - Chrome
+    // - ChromeCanary
+    // - Firefox
+    // - Opera
+    // - Safari (only Mac)
+    // - PhantomJS
+    // - IE (only Windows)
+    browsers: [
+      'Chrome'
+    ],
+
+    // If browser does not capture in given timeout [ms], kill it
+    captureTimeout: 60000,
+
+    // Continuous Integration mode
+    // if true, it capture browsers, run tests and exit
+    singleRun: false,
+
+    // Browserify config (all optional)
+    browserify: {
+      // extensions: ['.coffee'],
+      ignore: [
+        'superagent',
+        'supertest'
+      ],
+      // transform: ['coffeeify'],
+      debug: true,
+      // noParse: ['jquery'],
+      watch: true,
+    },
+
+    // Add browserify to preprocessors
+    preprocessors: {
+      'test/e2e/**': ['browserify'],
+      //'lib/*.js': ['browserify']
+    }
+  });
+};

--- a/test/rest-adapter.test.js
+++ b/test/rest-adapter.test.js
@@ -247,7 +247,7 @@ describe('RestAdapter', function() {
       methodConfig = extend({ shared: true }, methodConfig);
       classConfig = extend({ shared: true}, classConfig);
       remotes.testClass = extend({}, classConfig);
-      var fn = remotes.testClass[name] = extend(function(){}, methodConfig);
+      var fn = remotes.testClass[name] = extend(function() {}, methodConfig);
 
       var sharedClass = new SharedClass('testClass', remotes.testClass, true);
       var restClass = new RestAdapter.RestClass(sharedClass);

--- a/test/rest.browser.test.js
+++ b/test/rest.browser.test.js
@@ -7,16 +7,16 @@ var request = require('supertest');
 var expect = require('chai').expect;
 var factory = require('./helpers/shared-objects-factory.js');
 
-describe('strong-remoting-rest', function(){
+describe('strong-remoting-rest', function() {
   var app;
   var server;
   var objects;
   var remotes;
   var adapterName = 'rest';
-  
+
   before(function(done) {
     app = express();
-    app.use(function (req, res, next) {
+    app.use(function(req, res, next) {
       // create the handler for each request
       objects.handler(adapterName).apply(objects, arguments);
     });
@@ -24,16 +24,16 @@ describe('strong-remoting-rest', function(){
   });
 
   // setup
-  beforeEach(function(){
+  beforeEach(function() {
     objects = RemoteObjects.create();
     remotes = objects.exports;
-    
+
     // connect to the app
     objects.connect('http://localhost:' + server.address().port, adapterName);
   });
 
   describe('client', function() {
-    describe('call of constructor method', function(){
+    describe('call of constructor method', function() {
       it('should work', function(done) {
         var method = givenSharedStaticMethod(
           function greet(msg, cb) {
@@ -44,7 +44,7 @@ describe('strong-remoting-rest', function(){
             returns: { arg: 'msg', type: 'string' }
           }
         );
-        
+
         var msg = 'hello';
         objects.invoke(method.name, [msg], function(err, resMsg) {
           assert.equal(resMsg, msg);
@@ -87,7 +87,7 @@ describe('strong-remoting-rest', function(){
             http: { path: '/' }
           }
         );
-        
+
         objects.invoke(method.name, [1, 2], function(err, n) {
           assert.equal(n, 3);
           done();
@@ -115,7 +115,7 @@ describe('strong-remoting-rest', function(){
         });
       });
 
-      it('should pass undefined if the argument is not supplied', function (done) {
+      it('should pass undefined if the argument is not supplied', function(done) {
         var called = false;
         var method = givenSharedStaticMethod(
           function bar(a, cb) {
@@ -129,7 +129,7 @@ describe('strong-remoting-rest', function(){
             ]
           }
         );
-        
+
         objects.invoke(method.name, [], function(err) {
           assert(called);
           done();
@@ -149,7 +149,7 @@ describe('strong-remoting-rest', function(){
             http: { path: '/' }
           }
         );
-        
+
         var obj = {
           foo: 'bar'
         };
@@ -195,7 +195,7 @@ describe('strong-remoting-rest', function(){
             http: { path: '/' }
           }
         );
-        
+
         objects.invoke(method.name, [1, 2], function(err, n) {
           assert.equal(n, 3);
           done();
@@ -283,15 +283,15 @@ describe('strong-remoting-rest', function(){
         });
       });
 
-      describe('uncaught errors', function () {
-        it('should return 500 if an error object is thrown', function (done) {
+      describe('uncaught errors', function() {
+        it('should return 500 if an error object is thrown', function(done) {
           var errMsg = 'an error';
           var method = givenSharedStaticMethod(
             function(a, b, cb) {
               throw new Error(errMsg);
             }
           );
-          
+
           objects.invoke(method.name, function(err) {
             assert(err instanceof Error);
             assert.equal(err.message, errMsg);

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -9,8 +9,9 @@ var factory = require('./helpers/shared-objects-factory.js');
 
 var ACCEPT_XML_OR_ANY = 'application/xml,*/*;q=0.8';
 
-describe('strong-remoting-rest', function(){
-  var app, appSupportingJsonOnly;
+describe('strong-remoting-rest', function() {
+  var app;
+  var appSupportingJsonOnly;
   var server;
   var objects;
   var remotes;
@@ -19,7 +20,7 @@ describe('strong-remoting-rest', function(){
   before(function(done) {
     app = express();
     app.disable('x-powered-by');
-    app.use(function (req, res, next) {
+    app.use(function(req, res, next) {
       // create the handler for each request
       objects.handler(adapterName).apply(objects, arguments);
     });
@@ -28,7 +29,7 @@ describe('strong-remoting-rest', function(){
 
   before(function(done) {
     appSupportingJsonOnly = express();
-    appSupportingJsonOnly.use(function (req, res, next) {
+    appSupportingJsonOnly.use(function(req, res, next) {
       // create the handler for each request
       var supportedTypes = ['json', 'application/javascript', 'text/javascript'];
       var opts = { supportedTypes: supportedTypes };
@@ -38,7 +39,7 @@ describe('strong-remoting-rest', function(){
   });
 
   // setup
-  beforeEach(function(){
+  beforeEach(function() {
     if (process.env.NODE_ENV === 'production') {
       process.env.NODE_ENV = 'test';
     }
@@ -74,7 +75,7 @@ describe('strong-remoting-rest', function(){
       .expect('Content-Type', /xml/);
   }
 
-  describe('remoting options', function(){
+  describe('remoting options', function() {
     // The 1kb limit is set by RemoteObjects.create({json: {limit: '1kb'}});
     it('should reject json payload larger than 1kb', function(done) {
       var method = givenSharedStaticMethod(
@@ -168,7 +169,7 @@ describe('strong-remoting-rest', function(){
         .end(done);
     });
 
-    it('should turn off method-not-found handler',function(done){
+    it('should turn off method-not-found handler', function(done) {
       var method = givenSharedStaticMethod();
 
       objects.options.rest = { handleUnknownPaths: false };
@@ -176,7 +177,7 @@ describe('strong-remoting-rest', function(){
         res.send(404, 'custom-not-found');
       });
 
-      request(app).get(method.classUrl+'/thisMethodDoesNotExist')
+      request(app).get(method.classUrl + '/thisMethodDoesNotExist')
         .expect(404)
         .expect('custom-not-found')
         .end(done);
@@ -352,7 +353,7 @@ describe('strong-remoting-rest', function(){
     objects.options.rest.xml = true;
   }
 
-  describe('call of constructor method', function(){
+  describe('call of constructor method', function() {
     beforeEach(enableXmlSupport);
 
     it('should work', function(done) {
@@ -433,7 +434,7 @@ describe('strong-remoting-rest', function(){
         }
       );
 
-      json(method.classUrl +'/1?b=2')
+      json(method.classUrl + '/1?b=2')
         .expect({ n: 3 }, done);
     });
 
@@ -452,7 +453,7 @@ describe('strong-remoting-rest', function(){
         }
       );
 
-      json(method.classUrl +'/?a=1&b=2')
+      json(method.classUrl + '/?a=1&b=2')
         .expect({ n: 3 }, done);
     });
 
@@ -471,7 +472,7 @@ describe('strong-remoting-rest', function(){
         }
       );
 
-      json(method.classUrl +'/?a=z&b[0]=x&b[1]=y')
+      json(method.classUrl + '/?a=z&b[0]=x&b[1]=y')
         .expect({ n: 'xyz' }, done);
     });
 
@@ -491,7 +492,7 @@ describe('strong-remoting-rest', function(){
         }
       );
 
-      json(method.classUrl +'/?a=z&b=["x", "y"]')
+      json(method.classUrl + '/?a=z&b=["x", "y"]')
         .expect({ n: 'xyz' }, done);
     });
 
@@ -512,11 +513,11 @@ describe('strong-remoting-rest', function(){
         }
       );
 
-      json(method.classUrl +'/?a=1&b=2')
+      json(method.classUrl + '/?a=1&b=2')
         .expect({ n: 3 }, done);
     });
 
-    it('should pass undefined if the argument is not supplied', function (done) {
+    it('should pass undefined if the argument is not supplied', function(done) {
       var called = false;
       var method = givenSharedStaticMethod(
         function bar(a, cb) {
@@ -556,7 +557,7 @@ describe('strong-remoting-rest', function(){
         .set('Content-Type', 'application/json')
         .send('{"x": 1, "y": "Y"}')
         .expect('Content-Type', /json/)
-        .expect(200, function(err, res){
+        .expect(200, function(err, res) {
           expect(res.body).to.deep.equal({'x': 1, 'y': 'Y'});
           done(err, res);
         });
@@ -582,10 +583,10 @@ describe('strong-remoting-rest', function(){
         .set('Content-Type', 'application/json')
         .send(data)
         .expect('Content-Type', /json/)
-        .expect(200, function(err, res){
+        .expect(200, function(err, res) {
           expect(res.body).to.deep.equal({date: data.date.$data.toISOString()});
           done(err, res);
-      });
+        });
     });
 
     it('should allow arguments in the form', function(done) {
@@ -681,7 +682,7 @@ describe('strong-remoting-rest', function(){
         .set('Content-Type', 'application/json')
         .send('{"x": 1, "y": "Y"}')
         .expect('Content-Type', /json/)
-        .expect(200, function(err, res){
+        .expect(200, function(err, res) {
           expect(res.body).to.deep.equal({'x': 1, 'y': 'Y'});
           done(err, res);
         });
@@ -705,7 +706,7 @@ describe('strong-remoting-rest', function(){
         .set('Content-Type', 'application/json')
         .send('{"x": 1, "y": "Y"}')
         .expect('Content-Type', /json/)
-        .expect(200, function(err, res){
+        .expect(200, function(err, res) {
           expect(res.body).to.deep.equal({'x': 1, 'y': 'Y'});
           done(err, res);
         });
@@ -763,16 +764,15 @@ describe('strong-remoting-rest', function(){
 
       json(method.url)
         .expect(204)
-        .end(function(err,result){
-
+        .end(function(err, result) {
           expect(result.headers).not.to.have.keys(['x-powered-by']);
           done();
-      });
+        });
     });
 
     it('should report error for mismatched arg type', function(done) {
       remotes.foo = {
-        bar: function (a, fn) {
+        bar: function(a, fn) {
           fn(null, a);
         }
       };
@@ -791,7 +791,7 @@ describe('strong-remoting-rest', function(){
 
     it('should coerce boolean strings - true', function(done) {
       remotes.foo = {
-        bar: function (a, fn) {
+        bar: function(a, fn) {
           fn(null, a);
         }
       };
@@ -810,7 +810,7 @@ describe('strong-remoting-rest', function(){
 
     it('should coerce boolean strings - false', function(done) {
       remotes.foo = {
-        bar: function (a, fn) {
+        bar: function(a, fn) {
           fn(null, a);
         }
       };
@@ -829,7 +829,7 @@ describe('strong-remoting-rest', function(){
 
     it('should coerce number strings', function(done) {
       remotes.foo = {
-        bar: function (a, b, fn) {
+        bar: function(a, b, fn) {
           fn(null, a + b);
         }
       };
@@ -844,7 +844,7 @@ describe('strong-remoting-rest', function(){
       fn.returns = {root: true};
 
       json('get', '/foo/bar?a=42&b=0.42')
-        .expect(200, function (err, res) {
+        .expect(200, function(err, res) {
           assert.equal(res.body, 42.42);
           done();
         });
@@ -852,7 +852,7 @@ describe('strong-remoting-rest', function(){
 
     it('should allow empty body for json request', function(done) {
       remotes.foo = {
-        bar: function (a, b, fn) {
+        bar: function(a, b, fn) {
           fn(null, a, b);
         }
       };
@@ -1090,7 +1090,7 @@ describe('strong-remoting-rest', function(){
           }
         );
 
-        request(app).post(method.classUrl+'?_format=xml')
+        request(app).post(method.classUrl + '?_format=xml')
           .set('Accept', '*/*')
           .set('Content-Type', 'application/json')
           .send('{"x": 1, "y": "Y"}')
@@ -1116,7 +1116,7 @@ describe('strong-remoting-rest', function(){
           }
         );
 
-        request(app).post(method.classUrl+'?_format=json')
+        request(app).post(method.classUrl + '?_format=json')
           .set('Accept', 'application/xml')
           .set('Content-Type', 'application/json')
           .send('{"x": 1, "y": "Y"}')
@@ -1128,10 +1128,10 @@ describe('strong-remoting-rest', function(){
       });
     });
 
-    describe('uncaught errors', function () {
-      it('should return 500 if an error object is thrown', function (done) {
+    describe('uncaught errors', function() {
+      it('should return 500 if an error object is thrown', function(done) {
         remotes.shouldThrow = {
-          bar: function (fn) {
+          bar: function(fn) {
             throw new Error('an error');
           }
         };
@@ -1144,9 +1144,9 @@ describe('strong-remoting-rest', function(){
           .end(expectErrorResponseContaining({message: 'an error'}, done));
       });
 
-      it('should return 500 if an error string is thrown', function (done) {
+      it('should return 500 if an error string is thrown', function(done) {
         remotes.shouldThrow = {
-          bar: function (fn) {
+          bar: function(fn) {
             throw 'an error';
           }
         };
@@ -1197,7 +1197,7 @@ describe('strong-remoting-rest', function(){
         .end(expectErrorResponseContaining({message: 'test-error'}, done));
     });
 
-    it('should return 400 when a required arg is missing', function (done) {
+    it('should return 400 when a required arg is missing', function(done) {
       var method = givenSharedPrototypeMethod(
         function(a, cb) {
           cb();
@@ -1270,7 +1270,7 @@ describe('strong-remoting-rest', function(){
     });
   });
 
-  describe('call of prototype method', function(){
+  describe('call of prototype method', function() {
     it('should work', function(done) {
       var method = givenSharedPrototypeMethod(
         function greet(msg, cb) {
@@ -1317,11 +1317,11 @@ describe('strong-remoting-rest', function(){
         }
       );
 
-      json(method.getClassUrlForId('sum') +'/1?b=2')
+      json(method.getClassUrlForId('sum') + '/1?b=2')
         .expect({ n: 'sum:3' }, done);
     });
 
-    it('should allow jsonp requests', function (done) {
+    it('should allow jsonp requests', function(done) {
       var method = givenSharedStaticMethod(
         function bar(a, cb) {
           cb(null, a);
@@ -1342,7 +1342,7 @@ describe('strong-remoting-rest', function(){
         .expect('/**/ typeof boo === \'function\' && boo(1);', done);
     });
 
-    it('should allow jsonp requests with null response', function (done) {
+    it('should allow jsonp requests with null response', function(done) {
       var method = givenSharedStaticMethod(
         function bar(a, cb) {
           cb(null, null);
@@ -1377,7 +1377,7 @@ describe('strong-remoting-rest', function(){
         }
       );
 
-      json(method.getClassUrlForId('sum') +'/?b=2&a=1')
+      json(method.getClassUrlForId('sum') + '/?b=2&a=1')
         .expect({ n: 'sum:3' }, done);
     });
 
@@ -1519,7 +1519,7 @@ describe('strong-remoting-rest', function(){
 
   describe('client', function() {
 
-    describe('call of constructor method', function(){
+    describe('call of constructor method', function() {
       it('should work', function(done) {
         var method = givenSharedStaticMethod(
           function greet(msg, cb) {
@@ -1580,7 +1580,7 @@ describe('strong-remoting-rest', function(){
         });
       });
 
-      it('should pass undefined if the argument is not supplied', function (done) {
+      it('should pass undefined if the argument is not supplied', function(done) {
         var called = false;
         var method = givenSharedStaticMethod(
           function bar(a, cb) {
@@ -1691,8 +1691,8 @@ describe('strong-remoting-rest', function(){
         });
       });
 
-      describe('uncaught errors', function () {
-        it('should return 500 if an error object is thrown', function (done) {
+      describe('uncaught errors', function() {
+        it('should return 500 if an error object is thrown', function(done) {
           var errMsg = 'an error';
           var method = givenSharedStaticMethod(
             function(a, b, cb) {
@@ -1709,7 +1709,7 @@ describe('strong-remoting-rest', function(){
       });
     });
 
-    describe('call of prototype method', function(){
+    describe('call of prototype method', function() {
       it('should work', function(done) {
         var method = givenSharedPrototypeMethod(
           function greet(msg, cb) {
@@ -1770,7 +1770,7 @@ describe('strong-remoting-rest', function(){
         });
       });
 
-      it('should pass undefined if the argument is not supplied', function (done) {
+      it('should pass undefined if the argument is not supplied', function(done) {
         var called = false;
         var method = givenSharedPrototypeMethod(
           function bar(a, cb) {
@@ -1883,8 +1883,8 @@ describe('strong-remoting-rest', function(){
         });
       });
 
-      describe('uncaught errors', function () {
-        it('should return 500 if an error object is thrown', function (done) {
+      describe('uncaught errors', function() {
+        it('should return 500 if an error object is thrown', function(done) {
           var errMsg = 'an error';
           var method = givenSharedPrototypeMethod(
             function(a, b, cb) {
@@ -1944,7 +1944,7 @@ describe('strong-remoting-rest', function(){
   }
 
   function expectErrorResponseContaining(keyValues, excludedKeyValues, done) {
-    if(done === undefined && typeof excludedKeyValues === 'function') {
+    if (done === undefined && typeof excludedKeyValues === 'function') {
       done = excludedKeyValues;
       excludedKeyValues = {};
     }
@@ -1961,7 +1961,7 @@ describe('strong-remoting-rest', function(){
   }
 
   it('should skip the super class and only expose user defined remote methods',
-    function (done) {
+    function(done) {
 
       function base() {
       }
@@ -1993,7 +1993,5 @@ describe('strong-remoting-rest', function(){
       expect(methodNames).to.contain('foo.bar');
       expect(methodNames.length).to.equal(1);
       done();
-
-  });
-
+    });
 });

--- a/test/shared-class.test.js
+++ b/test/shared-class.test.js
@@ -20,7 +20,7 @@ describe('SharedClass', function() {
       var sc = new SharedClass('some', SomeClass);
       expect(sc.http.path).to.equal('/some');
     });
-    
+
     it('fills http.path using a normalized path', function() {
       var sc = new SharedClass('SomeClass', SomeClass, { normalizeHttpPath: true });
       expect(sc.http.path).to.equal('/some-class');
@@ -101,7 +101,7 @@ describe('SharedClass', function() {
   });
 
   describe('sharedClass.defineMethod(name, options)', function() {
-    it('defines a remote method', function () {
+    it('defines a remote method', function() {
       var sc = new SharedClass('SomeClass', SomeClass);
       SomeClass.prototype.myMethod = function() {};
       var METHOD_NAME = 'myMethod';
@@ -112,7 +112,7 @@ describe('SharedClass', function() {
       expect(methods).to.contain(METHOD_NAME);
     });
     it('should allow a shared class to resolve dynamically defined functions',
-      function (done) {
+      function(done) {
         var MyClass = function() {};
         var METHOD_NAME = 'dynFn';
         process.nextTick(function() {
@@ -131,8 +131,8 @@ describe('SharedClass', function() {
     );
   });
 
-  describe('sharedClass.resolve(resolver)', function () {
-    it('should allow sharedMethods to be resolved dynamically', function () {
+  describe('sharedClass.resolve(resolver)', function() {
+    it('should allow sharedMethods to be resolved dynamically', function() {
       function MyClass() {}
       MyClass.obj = {
         dyn: function(cb) {
@@ -148,7 +148,7 @@ describe('SharedClass', function() {
     });
   });
 
-  describe('sharedClass.find()', function () {
+  describe('sharedClass.find()', function() {
     var sc;
     var sm;
     beforeEach(function() {
@@ -159,17 +159,16 @@ describe('SharedClass', function() {
         prototype: true
       });
     });
-    it('finds sharedMethod for the given function', function () {
+    it('finds sharedMethod for the given function', function() {
       assert(sc.find(SomeClass.prototype.myMethod) === sm);
     });
-    it('find sharedMethod by name', function () {
+    it('find sharedMethod by name', function() {
       assert(sc.find('myMethod') === sm);
     });
   });
 
-
   describe('remotes.addClass(sharedClass)', function() {
-    it('should make the class available', function () {
+    it('should make the class available', function() {
       var CLASS_NAME = 'SomeClass';
       var remotes = RemoteObjects.create();
       var sharedClass = new SharedClass(CLASS_NAME, SomeClass);
@@ -179,7 +178,7 @@ describe('SharedClass', function() {
     });
   });
 
-  describe('sharedClass.disableMethod(methodName, isStatic)', function () {
+  describe('sharedClass.disableMethod(methodName, isStatic)', function() {
     var sc;
     var sm;
     var METHOD_NAME = 'testMethod';
@@ -195,24 +194,24 @@ describe('SharedClass', function() {
       });
     });
 
-    it('excludes disabled static methods from the method list', function () {
+    it('excludes disabled static methods from the method list', function() {
       sc.disableMethod(METHOD_NAME, true);
       var methods = sc.methods().map(getName);
       expect(methods).to.not.contain(METHOD_NAME);
     });
 
-    it('excludes disabled prototype methods from the method list', function () {
+    it('excludes disabled prototype methods from the method list', function() {
       sc.disableMethod(INST_METHOD_NAME, false);
       var methods = sc.methods().map(getName);
       expect(methods).to.not.contain(INST_METHOD_NAME);
     });
 
-    it('excludes disabled dynamic (resolved) methods from the method list', function () {
+    it('excludes disabled dynamic (resolved) methods from the method list', function() {
       sc.disableMethod(DYN_METHOD_NAME, true);
       var methods = sc.methods().map(getName);
       expect(methods).to.not.contain(DYN_METHOD_NAME);
-    })
-;  });
+    });
+  });
 });
 
 function getName(obj) {

--- a/test/shared-method.test.js
+++ b/test/shared-method.test.js
@@ -5,34 +5,34 @@ var SharedMethod = require('../lib/shared-method');
 var factory = require('./helpers/shared-objects-factory.js');
 
 describe('SharedMethod', function() {
-  describe('sharedMethod.isDelegateFor(suspect, [isStatic])', function () {
+  describe('sharedMethod.isDelegateFor(suspect, [isStatic])', function() {
 
     // stub function
     function myFunction() {}
 
-    it('checks if the given function is going to be invoked', function () {
+    it('checks if the given function is going to be invoked', function() {
       var mockSharedClass = {};
       var sharedMethod = new SharedMethod(myFunction, 'myName', mockSharedClass);
       assert.equal(sharedMethod.isDelegateFor(myFunction), true);
     });
-    
-    it('checks by name if a function is going to be invoked', function () {
+
+    it('checks by name if a function is going to be invoked', function() {
       var mockSharedClass = { prototype: { myName: myFunction } };
       var sharedMethod = new SharedMethod(myFunction, 'myName', mockSharedClass);
       assert.equal(sharedMethod.isDelegateFor('myName', false), true);
       assert.equal(sharedMethod.isDelegateFor('myName', true), false);
       assert.equal(sharedMethod.isDelegateFor('myName'), true);
     });
-    
-    it('checks by name if static function is going to be invoked', function () {
+
+    it('checks by name if static function is going to be invoked', function() {
       var mockSharedClass = { myName: myFunction };
       var options = { isStatic: true };
       var sharedMethod = new SharedMethod(myFunction, 'myName', mockSharedClass, options);
       assert.equal(sharedMethod.isDelegateFor('myName', true), true);
       assert.equal(sharedMethod.isDelegateFor('myName', false), false);
     });
-    
-    it('checks by alias if static function is going to be invoked', function () {
+
+    it('checks by alias if static function is going to be invoked', function() {
       var mockSharedClass = { myName: myFunction };
       var options = { isStatic: true, aliases: ['myAlias'] };
       var sharedMethod = new SharedMethod(myFunction, 'myName', mockSharedClass, options);
@@ -40,12 +40,12 @@ describe('SharedMethod', function() {
       assert.equal(sharedMethod.isDelegateFor('myAlias', false), false);
     });
 
-    it('checks if the given name is a string', function () {
+    it('checks if the given name is a string', function() {
       var mockSharedClass = {};
       var err;
       try {
         var sharedMethod = new SharedMethod(myFunction, Number, mockSharedClass);
-      } catch(e) {
+      } catch (e) {
         err = e;
       }
       assert(err);

--- a/test/streams.js
+++ b/test/streams.js
@@ -4,20 +4,22 @@ var express = require('express');
 var request = require('supertest');
 var fs = require('fs');
 
-describe('strong-remoting', function () {
-  var app, remotes, objects;
+describe('strong-remoting', function() {
+  var app;
+  var remotes;
+  var objects;
 
-  beforeEach(function(){
+  beforeEach(function() {
     objects = RemoteObjects.create();
     remotes = objects.exports;
     app = express();
     app.disable('x-powered-by');
 
-    app.use(function (req, res, next) {
+    app.use(function(req, res, next) {
       objects.handler('rest').apply(objects, arguments);
     });
   });
-  
+
   function json(method, url) {
     return request(app)[method](url)
       .set('Accept', 'application/json')
@@ -26,14 +28,14 @@ describe('strong-remoting', function () {
       .expect('Content-Type', /json/);
   }
 
-  it('should stream the file output', function (done) {
+  it('should stream the file output', function(done) {
     remotes.fs = fs;
     fs.createReadStream.shared = true;
     fs.createReadStream.accepts = [{arg: 'path', type: 'string'}];
     fs.createReadStream.returns = {arg: 'res', type: 'stream'};
     fs.createReadStream.http = {
       verb: 'get',
-      // path: '/fs/createReadStream', 
+      // path: '/fs/createReadStream',
       pipe: {
         dest: 'res'
       }

--- a/test/type.test.js
+++ b/test/type.test.js
@@ -2,13 +2,13 @@ var assert = require('assert');
 var Dynamic = require('../lib/dynamic');
 var RemoteObjects = require('../');
 
-describe('types', function () {
+describe('types', function() {
   var remotes;
   beforeEach(function() {
     remotes = RemoteObjects.create();
   });
-  describe('remotes.defineType(name, fn)', function () {
-    it('should define a new type converter', function () {
+  describe('remotes.defineType(name, fn)', function() {
+    it('should define a new type converter', function() {
       var name = 'MyType';
       remotes.defineType(name, function(val, ctx) {
         return val;
@@ -17,9 +17,9 @@ describe('types', function () {
     });
   });
 
-  describe('Dynamic(val, [ctx])', function () {
-    describe('Dynamic.to(typeName)', function () {
-      it('should convert the dynamic to the given type', function () {
+  describe('Dynamic(val, [ctx])', function() {
+    describe('Dynamic.to(typeName)', function() {
+      it('should convert the dynamic to the given type', function() {
         Dynamic.define('beep', function(str) {
           return 'boop';
         });
@@ -27,14 +27,14 @@ describe('types', function () {
         assert.equal(dyn.to('beep'), 'boop');
       });
     });
-    describe('Dynamic.canConvert(typeName)', function () {
-      it('should only return true when a converter exists', function () {
+    describe('Dynamic.canConvert(typeName)', function() {
+      it('should only return true when a converter exists', function() {
         Dynamic.define('MyType', function() {});
         assert(Dynamic.canConvert('MyType'));
         assert(!Dynamic.canConvert('FauxType'));
       });
     });
-    describe('Built in converters', function(){
+    describe('Built in converters', function() {
       it('should convert Boolean values', function() {
         shouldConvert(true, true);
         shouldConvert(false, false);
@@ -51,7 +51,7 @@ describe('types', function () {
         shouldConvert('null', false);
         shouldConvert('undefined', false);
         shouldConvert('', false);
-        
+
         function shouldConvert(val, expected) {
           var dyn = new Dynamic(val);
           assert.equal(dyn.to('boolean'), expected);
@@ -67,14 +67,14 @@ describe('types', function () {
         shouldConvert(false, 0);
         shouldConvert({}, 'NaN');
         shouldConvert([], 0);
-        
+
         function shouldConvert(val, expected) {
           var dyn = new Dynamic(val);
-          
-          if(expected === 'NaN') {
+
+          if (expected === 'NaN') {
             return assert(Number.isNaN(dyn.to('number')));
           }
-          
+
           assert.equal(dyn.to('number'), expected);
         }
       });


### PR DESCRIPTION
Add jscs, make both jshint and jscs a part of CI build process (`npm test`).

Fix all violations of the coding style.

`.jscsrc` is based on the config file from loopback, .`jshintrc` remains practically unchanged.

/cc @raymondfeng @ritch Most of the changes are white-space changes and the config is based on what we already have in loopback, therefore I feel this patch does not need to wait for your approval. However, if you find anything suspicious, I'll address it in a follow-up PR.
