### PR TITLE
Don't crash on improperly formatted inputs. Introduced in #131 and fixes #144.

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -203,9 +203,10 @@ SharedMethod.prototype.invoke = function(scope, args, remotingOptions, cb) {
             uarg = convertValueToTargetType(uarg, targetType);
           }
         } catch (err) {
-          debug('- %s - invalid value for argument \'%s\' of type \'%s\': %s',
-            sharedMethod.name, name, desc.type, uarg);
-          throw err;
+          var message = util.format('invalid value for argument \'%s\' of type \'%s\': %s',
+            name, desc.type, uarg);
+          debug('- %s - ' + message, sharedMethod.name);
+          return cb(badArgumentError(message));
         }
       }
 
@@ -249,7 +250,7 @@ function badArgumentError(msg) {
 
 function escapeRegex(d) {
   // see http://stackoverflow.com/a/6969486/69868
-  return d.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+  return d.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
 }
 
 function convertValueToTargetType(value, targetType) {

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -786,7 +786,7 @@ describe('strong-remoting-rest', function() {
       fn.returns = {root: true};
 
       json('get', '/foo/bar?a=foo')
-        .expect(500, done);
+        .expect(400, done);
     });
 
     it('should coerce boolean strings - true', function(done) {

--- a/test/shared-method.test.js
+++ b/test/shared-method.test.js
@@ -68,6 +68,21 @@ describe('SharedMethod', function() {
       });
     });
 
+    it('returns 400 and doesn\'t crash with unparsable object', function(done) {
+      var method = givenSharedMethod({
+        accepts: [{ arg: 'obj', type: 'object' }]
+      });
+
+      method.invoke('ctx', { obj: 'test' }, function(err) {
+        setImmediate(function() {
+          expect(err).to.exist();
+          expect(err.message).to.contain('invalid value for argument');
+          expect(err.statusCode).to.equal(400);
+          done();
+        });
+      });
+    });
+
     function givenSharedMethod(options) {
       var aFn = function() {
         arguments[arguments.length - 1]();


### PR DESCRIPTION
This bug was introduced in #131 and fixes #144.

This is critical IMO as servers deployed with strong-remoting `2.10.0` and not using domains will crash on any invalid input.

This PR properly restores the previous behavior of calling back with an error when presented with invalid input, and also properly sets a `400` status and a helpful error message.

When invoking a function with an improperly formatted object (`test`), for example, rather than the message (which was the behavior before the merging of #131 - now you just get a crash):

```
{
  "error": {
    "message": "SyntaxError: Unexpected token t",
  }
}
```

One will now see something like:

```
{
  "error": {
    "message": "invalid value for argument 'filter' of type 'object': test",
    "status": 400
  }
}
```
