### PR TITLE
Allow accessType to be configured per shared method

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -77,6 +77,7 @@ function SharedMethod(fn, name, sc, options) {
   this.returns = options.returns || fn.returns || [];
   this.errors = options.errors || fn.errors || [];
   this.description = options.description || fn.description;
+  this.accessType = options.accessType || fn.accessType;
   this.notes = options.notes || fn.notes;
   this.documented = (options.documented || fn.documented) !== false;
   this.http = options.http || fn.http || {};

--- a/test/shared-class.test.js
+++ b/test/shared-class.test.js
@@ -111,6 +111,20 @@ describe('SharedClass', function() {
       var methods = sc.methods().map(getName);
       expect(methods).to.contain(METHOD_NAME);
     });
+
+    it('defines a remote method with accessType', function() {
+      var sc = new SharedClass('SomeClass', SomeClass);
+      SomeClass.prototype.myMethod = function() {};
+      var METHOD_NAME = 'myMethod';
+      sc.defineMethod(METHOD_NAME, {
+        prototype: true,
+        accessType: 'READ'
+      });
+      var methods = sc.methods().map(getName);
+      expect(methods).to.contain(METHOD_NAME);
+      expect(sc.find(METHOD_NAME).accessType).to.eql('READ');
+    });
+
     it('should allow a shared class to resolve dynamically defined functions',
       function(done) {
         var MyClass = function() {};


### PR DESCRIPTION
/to @ritch 

The PR allows accessType to be configured per shared method to avoid hard-coding accessType mapping of remote methods for ACL. See https://github.com/strongloop/strong-remoting/issues/146.