### PR TITLE
Add remote hooks to restAdapter.invoke method

### DIFF
--- a/lib/http-invocation.js
+++ b/lib/http-invocation.js
@@ -157,7 +157,7 @@ HttpInvocation.prototype.createRequest = function() {
   var args = {};
   var method = this.method;
   var verb = method.getHttpMethod();
-  var req = {json: true, method: verb || 'GET'};
+  var req = this.req = {json: true, method: verb || 'GET'};
   var accepts = method.accepts;
   var ctorAccepts = null;
   var returns = method.returns;
@@ -202,14 +202,25 @@ HttpInvocation.prototype.getArgByName = function(name) {
  */
 
 HttpInvocation.prototype.invoke = function(callback) {
-  var req = this.createRequest();
-  request(req, function(err, res, body) {
+  if (!this.req) {
+    this.createRequest();
+  }
+  request(this.req, function(err, res, body) {
     if (err instanceof SyntaxError) {
       if (res.status === 204) err = null;
     }
     if (err) return callback(err);
+    this.res = res;
     this.transformResponse(res, body, callback);
   }.bind(this));
+};
+
+/*
+ * Get Response object
+ */
+
+HttpInvocation.prototype.getResponse = function() {
+  return this.res || null;
 };
 
 /**

--- a/lib/remote-objects.js
+++ b/lib/remote-objects.js
@@ -299,8 +299,9 @@ RemoteObjects.prototype.after = function(methodMatch, fn) {
 RemoteObjects.prototype.execHooks = function(when, method, scope, ctx, next) {
   var stack = [];
   var ee = this;
-  var type = when + '.' + method.sharedClass.name +
-    (method.isStatic ? '.' : '.prototype.') + method.name;
+  var isStatic = method.isStatic ||
+    method.sharedMethod && method.sharedMethod.isStatic;
+  var type;
 
   // Commented-out by bajtos: init is not defined.
   // this._events || init.call(this);
@@ -308,8 +309,17 @@ RemoteObjects.prototype.execHooks = function(when, method, scope, ctx, next) {
   var handler;
 
   // context
-  this.objectName = method.sharedClass.name;
+  this.objectName = method.sharedClass && method.sharedClass.name ||
+    method.restClass && method.restClass.name;
+
   this.methodName = method.name;
+
+  if (method.fullName) {
+    type = when + '.' + method.fullName;
+  } else {
+    type = when + '.' + this.objectName +
+      (isStatic ? '.' : '.prototype.') + this.methodName;
+  }
 
   if (this.wildcard) {
     handler = [];
@@ -518,7 +528,9 @@ RemoteObjects.prototype.invokeMethodInContext = function(ctx, method, cb) {
 RemoteObjects.prototype.getScope = function(ctx, method) {
   // Static methods are invoked on the constructor (this = constructor fn)
   // Prototype methods are invoked on the instance (this = instance)
-  return ctx.instance || method.ctor;
+  return ctx.instance ||
+    method.ctor ||
+    method.sharedMethod && method.sharedMethod.ctor;
 };
 
 /**

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -111,9 +111,26 @@ RestAdapter.prototype.invoke = function(method, ctorArgs, args, callback) {
     ctorArgs = [];
   }
 
+  var remotes = this.remotes;
   var restMethod = this.getRestMethodByName(method);
   var invocation = new HttpInvocation(restMethod, ctorArgs, args, this.connection);
-  invocation.invoke(callback);
+  var ctx = { req: invocation.createRequest() };
+  var scope = remotes.getScope(ctx, restMethod);
+  remotes.execHooks('before', restMethod, scope, ctx, function(err) {
+    if (err) { return callback(err); }
+    invocation.invoke(function() {
+      if (err) { return callback(err); }
+      var args = Array.prototype.slice.call(arguments);
+
+      ctx.result = args.slice(1);
+      ctx.res = invocation.getResponse();
+      remotes.execHooks('after', restMethod, scope, ctx, function(err) {
+        if (err) { return callback(err); }
+
+        callback.apply(invocation, args);
+      });
+    });
+  });
 };
 
 RestAdapter.prototype.getRestMethodByName = function(name) {


### PR DESCRIPTION
Hooks on invoke are needed to use methods like User login/logout 
in the browser with loopback remotely from loopback-connector-remote.
see https://github.com/strongloop/strong-remoting/issues/150
and https://github.com/strongloop/strong-remoting/issues/105
and https://github.com/strongloop/loopback/pull/943