### PR TITLE
Optimize performance of http-context

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -65,7 +65,9 @@ HttpContext.prototype.buildArgs = function(method) {
   var errors = method.errors;
 
   // build arguments from req and method options
-  accepts.forEach(function(o) {
+  // Use for loop instead of .forEach to get better performance
+  for (var ix = 0; ix < accepts.length; ix++) {
+    var o = accepts[ix];
     var httpFormat = o.http;
     var name = o.name || o.arg;
     var val;
@@ -126,7 +128,7 @@ HttpContext.prototype.buildArgs = function(method) {
 
     // set the argument value
     args[o.arg] = val;
-  }.bind(this));
+  }
 
   return args;
 };


### PR DESCRIPTION
Replace `.forEach()` + `.bind()` with a regular for loop.

/to @raymondfeng please review

Note: the problem addressed by this patch was pointed out in strongloop/loopback-benchmarks#1 as a possible improvement. I run the benchmark again with the patched version of loopback, but I did not observe any performance improvement greater that the variations in the measured data.