### PR TITLE
Remove use of deprecated req.param()

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -139,25 +139,44 @@ HttpContext.prototype.buildArgs = function(method) {
  */
 
 HttpContext.prototype.getArgByName = function(name, options) {
+  // Performance is important here. Reduce access to objects.
   var req = this.req;
-  var args = req.param('args');
+  var params = req.params;
+  var body = req.body || {}; // can be undefined.
+  var query  = req.query;
+
+  // Use same order as the deprecated req.param() used.
+  var args = params.args || body.args || query.args;
+  var arg;
 
   if (args) {
     args = JSON.parse(args);
   }
 
-  if (typeof args !== 'object' || !args) {
+  if (typeof args !== 'object') {
     args = {};
   }
 
-  var arg = (args && args[name] !== undefined) ? args[name] :
-            this.req.param(name) !== undefined ? this.req.param(name) :
-            this.req.get(name);
   // search these in order by name
+  // args
   // req.params
   // req.body
   // req.query
-  // req.header
+  // req.header (req.get())
+  var searchables = [args, params, body, query];
+  for (var i = 0; i < searchables.length; i++) {
+    // All searchables are defaulted to {}
+    var _arg = searchables[i][name];
+    if (_arg !== undefined) {
+      arg = _arg;
+      break;
+    }
+  }
+  // Look for header lastly. This is the only case-insensitive lookup.
+  // Can't we just add req.header to searchables for consistency?
+  // Or is the case-insensitivity of this header lookup intentional
+  // and documented?
+  if (arg === undefined) { arg = req.get(name); }
 
   // coerce simple types in objects
   if (typeof arg === 'object') {


### PR DESCRIPTION
Express 4.11.0 adds deprecation warnings about this usage. Refactor
HttpContext.getArgByName() to access req.params, req.body and
req.query directly.