### PR TITLE
Add proper support for remotes using HTTP authentication

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -13,6 +13,7 @@
    "it": false,
    "describe": false,
    "before": false,
+   "after": false,
    "beforeEach": false,
    "afterEach": false
 }

--- a/lib/http-invocation.js
+++ b/lib/http-invocation.js
@@ -18,6 +18,7 @@ var request = require('request');
 var Dynamic = require('./dynamic');
 var SUPPORTED_TYPES = ['json', 'application/javascript', 'text/javascript'];
 var qs = require('qs');
+var urlUtil = require('url');
 
 /*!
  * JSON Types
@@ -38,6 +39,21 @@ var JSON_TYPES = ['boolean', 'string', 'object', 'number'];
 
 function HttpInvocation(method, ctorArgs, args, base) {
   this.base = base;
+  if (this.base) {
+    var url = urlUtil.parse(base);
+    // If base url contains auth, extract it so we can set it separately
+    if (url.auth) {
+      this.username = url.auth.split(':')[0];
+      this.password = url.auth.split(':')[1];
+      // set base without auth so request honours our auth options
+      delete url.auth;
+      this.base = urlUtil.format(url);
+      // ensure a "/" hasn't been appended where there wasn't one before
+      if (base[base.length - 1] !== this.base[this.base.length - 1]) {
+        this.base = this.base.slice(0, -1);
+      }
+    }
+  }
   this.method = method;
   this.args = args || [];
   this.ctorArgs = ctorArgs || [];
@@ -164,6 +180,18 @@ HttpInvocation.prototype.createRequest = function() {
 
   // initial url is the format
   req.url = this.base + method.getFullPath();
+
+  // add auth if it is set
+  if (this.username && this.password) {
+    req.auth = {
+      // request defaults to sending auth immidiately, which works for
+      // Basic auth, but doesn't work for Digest auth
+      // Note: these options are ignored if the URL still contains credentials
+      sendImmediately: false,
+      user: this.username,
+      pass: this.password,
+    };
+  }
 
   // build request args and method options
   if (!this.isStatic) {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "grunt-contrib-watch": "~0.6.1",
     "grunt-jscs": "^0.8.1",
     "grunt-karma": "~0.9.0",
+    "http-auth": "^2.2.5",
     "karma": "~0.12.23",
     "karma-browserify": "0.2.1",
     "karma-chrome-launcher": "~0.1.4",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "chai": "^1.10.0",
     "grunt": "~0.4.5",
     "grunt-browserify": "~3.0.1",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "~0.5.1",
     "grunt-contrib-watch": "~0.6.1",

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -1,0 +1,96 @@
+var auth = require('http-auth');
+var crypto = require('crypto');
+var expect = require('chai').expect;
+var express = require('express');
+var fmt = require('util').format;
+
+var RemoteObjects = require('../');
+var User = require('./e2e/fixtures/user');
+
+describe('support for HTTP Authentication', function() {
+  var server;
+  var remotes = RemoteObjects.create();
+  remotes.exports.User = User;
+
+  before(function setupServer(done) {
+    var app = express();
+    var basic = auth.basic({ realm: 'testing' }, function(u, p, cb) {
+      cb(u === 'basicuser' && p === 'basicpass');
+    });
+    var digest = auth.digest({ realm: 'testing' }, function(user, cb) {
+      cb(user === 'digestuser' ? md5('digestuser:testing:digestpass') : null);
+    });
+    app.use('/noAuth', remotes.handler('rest'));
+    app.use('/basicAuth', auth.connect(basic), remotes.handler('rest'));
+    app.use('/digestAuth', auth.connect(digest), remotes.handler('rest'));
+    server = app.listen(0, '127.0.0.1', done);
+  });
+
+  after(function teardownServer(done) {
+    server.close(done);
+  });
+
+  describe('when no authentication is required', function() {
+    it('succeeds without credentials',
+       succeeds('/noAuth'));
+    it('succeeds with credentials',
+       succeeds('/noAuth', 'extrauser:extrapass'));
+  });
+
+  describe('when Basic auth is required', function() {
+    it('succeeds with correct credentials',
+       succeeds('/basicAuth', 'basicuser:basicpass'));
+    it('fails when bad credentials are given',
+       fails('/basicAuth', 'baduser:badpass'));
+    it('fails when no credentials are given',
+       fails('/basicAuth'));
+  });
+
+  describe('when Digest auth is required', function() {
+    it('succeeds with correct credentials',
+       succeeds('/digestAuth', 'digestuser:digestpass'));
+    it('fails with bad credentials',
+       fails('/digestAuth', 'baduser:badpass'));
+    it('fails with no credentials',
+       fails('/digestAuth'));
+  });
+
+  function succeeds(path, credentials) {
+    return function(done) {
+      invokeRemote(server.address().port, path, credentials,
+                   function(err, session) {
+                     expect(err).to.not.exist();
+                     expect(session.userId).to.equal(123);
+                     done();
+                   });
+    };
+  }
+
+  function fails(path, credentials) {
+    return function(done) {
+      invokeRemote(server.address().port, path, credentials,
+                   function(err, session) {
+                     expect(err).to.match(/401/);
+                     done();
+                   });
+    };
+  }
+
+  function invokeRemote(port, path, credentials, callback) {
+    credentials = credentials || '';
+    if (credentials.length > 0) {
+      credentials += '@';
+    }
+    var url = fmt('http://%s127.0.0.1:%d%s', credentials, port, path);
+    var method = 'User.login';
+    var args = [{username: 'joe', password: 'secret'}];
+    remotes.connect(url, 'rest');
+    remotes.invoke(method, args, callback);
+  }
+});
+
+function md5(str) {
+  var hash = crypto.createHash('md5');
+  hash.update(str);
+  return hash.digest('hex');
+}


### PR DESCRIPTION
 * [x] Add tests for existing Basic auth support (to formalize support and guard against regressions)
 * [x] Add tests for Digest auth
 * [x] Add support for Digest auth remotes

This is necessary to allow loopback-connector-remote to support backends that use Digest auth, which is required to allow strong-pm (or any other backend) to support Digest auth.

/cc @sam-github @kraman 