### PR TITLE
Update use of request.param(name) to request.params[name]

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -150,7 +150,7 @@ HttpContext.prototype.getArgByName = function(name, options) {
   }
 
   var arg = (args && args[name] !== undefined) ? args[name] :
-            this.req.param(name) !== undefined ? this.req.param(name) :
+            this.req.params[name] !== undefined ? this.req.params[name] :
             this.req.get(name);
   // search these in order by name
   // req.params


### PR DESCRIPTION
Express deprecated the use of request.param(name).

Signed-off-by: bradplank <brad@bradplank.com>