### PR TITLE
Support disabling CORS by setting config value to false

### DIFF
--- a/lib/jsonrpc-adapter.js
+++ b/lib/jsonrpc-adapter.js
@@ -118,11 +118,16 @@ JsonRpcAdapter.prototype.createHandler = function() {
   debug('remoting options: %j', this.remotes.options);
   var jsonOptions = this.remotes.options.json || {strict: false};
   var corsOptions = this.remotes.options.cors || {origin: true, credentials: true};
+  if (this.remotes.options.cors === false) {
+    corsOptions = false;
+  }
 
   // Optimize the cors handler
   var corsHandler = function(req, res, next) {
     var reqUrl = req.protocol + '://' + req.get('host');
-    if (req.method === 'OPTIONS' || reqUrl !== req.get('origin')) {
+    if (corsOptions === false) {
+      next();
+    } else if (req.method === 'OPTIONS' || reqUrl !== req.get('origin')) {
       cors(corsOptions)(req, res, next);
     } else {
       next();

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -233,11 +233,16 @@ RestAdapter.prototype.createHandler = function() {
   }
   var jsonOptions = this.remotes.options.json || {strict: false};
   var corsOptions = this.remotes.options.cors || {origin: true, credentials: true};
+  if (this.remotes.options.cors === false) {
+    corsOptions = false;
+  }
 
   // Optimize the cors handler
   var corsHandler = function(req, res, next) {
     var reqUrl = req.protocol + '://' + req.get('host');
-    if (req.method === 'OPTIONS' || reqUrl !== req.get('origin')) {
+    if (corsOptions === false) {
+      next();
+    } else if (req.method === 'OPTIONS' || reqUrl !== req.get('origin')) {
       cors(corsOptions)(req, res, next);
     } else {
       next();

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "body-parser": "^1.7.0",
     "debug": "^2.0.0",
     "eventemitter2": "^0.4.14",
-    "cors": "^2.4.1",
+    "cors": "^2.5.2",
     "jayson": "^1.1.1",
     "js2xmlparser": "^0.1.3",
     "async": "^0.9.0",

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -346,6 +346,32 @@ describe('strong-remoting-rest', function() {
         .expect(400, done);
     });
 
+    it('OPTIONS requests should skip cors if config is false', function(done) {
+      objects.options.cors = false;
+      request(app).options(method.url)
+        .set('Accept', 'application/json')
+        .set('Content-Type', 'application/json')
+        .set('Origin', 'http://localhost:3001')
+        .send()
+        // http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.2
+        .expect(200, function(err, res) {
+          expect(res.get('Access-Control-Allow-Origin')).to.not.exist();
+          done(err, res);
+        });
+    });
+
+    it('should skip cors headers if config is false', function(done) {
+      objects.options.cors = false;
+      request(app).post(method.url)
+        .set('Accept', 'application/json')
+        .set('Content-Type', 'application/json')
+        .set('Origin', 'http://localhost:3001')
+        .send({person: 'ABC'})
+        .expect(200, function(err, res) {
+          expect(res.get('Access-Control-Allow-Origin')).to.not.exist();
+          done(err, res);
+        });
+    });
   });
 
   function enableXmlSupport() {


### PR DESCRIPTION
CORS headers may be enabled/handled elsewhere in the application stack, so strong-remoting should support the ability to turn its internal use of CORS off entirely.

See https://github.com/strongloop/loopback/issues/575