### PR TITLE
fix express deprecated req.param(name)

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -139,7 +139,7 @@ HttpContext.prototype.buildArgs = function(method) {
 
 HttpContext.prototype.getArgByName = function(name, options) {
   var req = this.req;
-  var args = req.param('args');
+  var args = req.params('args');
 
   if (args) {
     args = JSON.parse(args);
@@ -150,7 +150,7 @@ HttpContext.prototype.getArgByName = function(name, options) {
   }
 
   var arg = (args && args[name] !== undefined) ? args[name] :
-            this.req.param(name) !== undefined ? this.req.param(name) :
+            this.req.params(name) !== undefined ? this.req.params(name) :
             this.req.get(name);
   // search these in order by name
   // req.params


### PR DESCRIPTION
    express deprecated req.param(name): Use req.params, req.body, or req.query instead node_modules/loopback/node_modules/strong-remoting/lib/http-context.js:142:18
    express deprecated req.param(name): Use req.params, req.body, or req.query instead node_modules/loopback/node_modules/strong-remoting/lib/http-context.js:153:22