### PR TITLE
Catch unhandled error on current method invocation

### DIFF
--- a/lib/remote-objects.js
+++ b/lib/remote-objects.js
@@ -359,7 +359,11 @@ RemoteObjects.prototype.execHooks = function(when, method, scope, ctx, next) {
     var cur = stack.shift();
 
     if (cur) {
-      cur.call(scope, ctx, execStack, method);
+      try {
+        cur.call(scope, ctx, execStack, method);
+      } catch (err) {
+        next(err);
+      }
     } else {
       next();
     }

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -1184,6 +1184,23 @@ describe('strong-remoting-rest', function() {
           .expect(500)
           .end(expectErrorResponseContaining({message: 'an error'}, done));
       });
+
+      it('should return 500 for unhandled errors thrown from before hooks', function(done) {
+        var method = givenSharedStaticMethod();
+
+        objects.before(method.name, function(ctx, next) {
+          process.nextTick(next);
+        });
+
+        objects.before(method.name, function(ctx, next) {
+          throw new Error('test error');
+        });
+
+        request(app).get(method.url)
+          .set('Accept', 'application/json')
+          .expect(500)
+          .end(expectErrorResponseContaining({ message: 'test error' }, done));
+      });
     });
 
     it('should return 500 when method returns an error', function(done) {


### PR DESCRIPTION
to/ @bajtos 
Made following changes for issue#709
- In remote-objects.js Enclosed the call to cur.call with try-catch block
- Added test case to verify that unhandled exceptions, do not crash the server.

Can you please review?