### PR TITLE
Fix jscs settings

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -8,6 +8,7 @@
      "catch"
   ],
   "disallowSpacesInsideObjectBrackets": null,
+  "disallowMultipleVarDecl": "exceptUndefined",
   "maximumLineLength": {
      "value": 92,
      "allowComments": false,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,7 +39,7 @@ module.exports = function(grunt) {
     jscs: {
       gruntfile: 'Gruntfile.js',
       lib: '<%= jshint.lib.src %>',
-      test: '<%= jshint.lib.src %>'
+      test: '<%= jshint.test.src %>'
     },
     watch: {
       gruntfile: {

--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -207,10 +207,9 @@ SharedMethod.prototype.invoke = function(scope, args, remotingOptions, cb) {
               debug('convert %j to %s', uarg[ix], targetType[0]);
               uarg[ix] = convertValueToTargetType(uarg[ix], targetType[0]);
             }
-          }
-          // Target isn't an array, or arrayItemDelimiters weren't specified. At this
-          // point we're out of options so let's throw.
-          else {
+          } else {
+            // Target isn't an array, or arrayItemDelimiters weren't specified. At this
+            // point we're out of options so let's throw.
             var message = util.format('invalid value for argument \'%s\' of type ' +
               '\'%s\': %s', name, desc.type, uarg);
             debug('- %s - ' + message, sharedMethod.name);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "~0.5.1",
     "grunt-contrib-watch": "~0.6.1",
-    "grunt-jscs": "^0.8.1",
+    "grunt-jscs": "^1.2.0",
     "grunt-karma": "~0.9.0",
     "http-auth": "^2.2.5",
     "karma": "~0.12.23",

--- a/test/rest-adapter.test.js
+++ b/test/rest-adapter.test.js
@@ -403,7 +403,6 @@ describe('RestAdapter', function() {
         next();
       });
 
-
       var restAdapter = givenRestStaticMethod({ isStatic: true });
       restAdapter.connect('foo');
       restAdapter.invoke(name, [], [], function() {


### PR DESCRIPTION
Upgrade grunt-jscs to the latest version.

Fix definition of test files in Gruntfile.js

Allow declaration of multiple variables in a single statement when
the variables are not initialized.