### PR TITLE
Support Promise-returning method and hooks

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -10,6 +10,7 @@
 "undef": true,
 "laxcomma" : true,
 "globals" : {
+   "Promise": true,
    "it": false,
    "describe": false,
    "before": false,

--- a/lib/remote-objects.js
+++ b/lib/remote-objects.js
@@ -360,7 +360,10 @@ RemoteObjects.prototype.execHooks = function(when, method, scope, ctx, next) {
 
     if (cur) {
       try {
-        cur.call(scope, ctx, execStack, method);
+        var result = cur.call(scope, ctx, execStack, method);
+        if (result && typeof result.then === 'function') {
+          result.then(function() { next(); }, next);
+        }
       } catch (err) {
         next(err);
       }

--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -151,7 +151,6 @@ SharedMethod.prototype.invoke = function(scope, args, remotingOptions, cb) {
   var method = this.getFunction();
   var sharedMethod = this;
   var formattedArgs = [];
-  var result;
 
   if (cb === undefined && typeof remotingOptions === 'function') {
     cb = remotingOptions;
@@ -229,7 +228,7 @@ SharedMethod.prototype.invoke = function(scope, args, remotingOptions, cb) {
       return cb(err);
     }
 
-    result = SharedMethod.toResult(returns, [].slice.call(arguments, 1));
+    var result = SharedMethod.toResult(returns, [].slice.call(arguments, 1));
 
     debug('- %s - result %j', sharedMethod.name, result);
 
@@ -243,7 +242,18 @@ SharedMethod.prototype.invoke = function(scope, args, remotingOptions, cb) {
 
   // invoke
   try {
-    return method.apply(scope, formattedArgs);
+    var retval = method.apply(scope, formattedArgs);
+    if (retval && typeof retval.then === 'function') {
+      return retval.then(
+        function(args) {
+          var result = SharedMethod.toResult(returns, args);
+          debug('- %s - promise result %j', sharedMethod.name, result);
+          cb(null, result);
+        },
+        cb // error handler
+      );
+    }
+    return retval;
   } catch (err) {
     debug('error caught during the invocation of %s', this.name);
     return cb(err);

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "xml2js": "^0.4.4"
   },
   "devDependencies": {
+    "bluebird": "^2.9.6",
     "browserify": "~5.11.1",
     "chai": "^1.10.0",
     "grunt": "~0.4.5",


### PR DESCRIPTION
If a shared method or a hook handler returns a duck-typed promise, i.e. an object with a `then` method, then the invocation waits until the promise is fulfilled or rejected.

Connect strongloop/loopback#418

/to @raymondfeng @ritch please review