### PR TITLE
Allow promises to resolve with a single arg

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -246,6 +246,7 @@ SharedMethod.prototype.invoke = function(scope, args, remotingOptions, cb) {
     if (retval && typeof retval.then === 'function') {
       return retval.then(
         function(args) {
+          if (returns.length === 1) args = [args];
           var result = SharedMethod.toResult(returns, args);
           debug('- %s - promise result %j', sharedMethod.name, result);
           cb(null, result);

--- a/test/shared-method.test.js
+++ b/test/shared-method.test.js
@@ -106,6 +106,48 @@ describe('SharedMethod', function() {
       });
     });
 
+    it('handles promise resolved with a single arg', function(done) {
+      var method = givenSharedMethod(
+        function() {
+          return new Promise(function(resolve, reject) {
+            resolve('data');
+          });
+        },
+        {
+          returns: [
+            { arg: 'value', type: 'string' },
+          ]
+        });
+
+      method.invoke('ctx', {}, function(err, result) {
+        setImmediate(function() {
+          expect(result).to.eql({ value: 'data' });
+          done();
+        });
+      });
+    });
+
+    it('handles promise resolved with a single array arg', function(done) {
+      var method = givenSharedMethod(
+        function() {
+          return new Promise(function(resolve, reject) {
+            resolve(['a', 'b']);
+          });
+        },
+        {
+          returns: [
+            { arg: 'value', type: ['string']},
+          ]
+        });
+
+      method.invoke('ctx', {}, function(err, result) {
+        setImmediate(function() {
+          expect(result).to.eql({ value: ['a', 'b'] });
+          done();
+        });
+      });
+    });
+
     it('handles rejected promise returned from the method', function(done) {
       var testError = new Error('expected test error');
       var method = givenSharedMethod(function() {


### PR DESCRIPTION
A follow-up for #179, connect strongloop/loopback#418

Comparison of callback and promise APIs:

```
callback(null, value) <===> resolve(value)
callback(null, arg1, arg2) <===> resolve([arg1, arg2])
```

/to @raymondfeng @ritch please review