### PR TITLE
Add remotes.auth / authorization support

### DIFF
--- a/lib/http-invocation.js
+++ b/lib/http-invocation.js
@@ -37,23 +37,9 @@ var JSON_TYPES = ['boolean', 'string', 'object', 'number'];
  * @property {Array} args The arguments to be used when invoking the `SharedMethod`
  */
 
-function HttpInvocation(method, ctorArgs, args, base) {
+function HttpInvocation(method, ctorArgs, args, base, auth) {
   this.base = base;
-  if (this.base) {
-    var url = urlUtil.parse(base);
-    // If base url contains auth, extract it so we can set it separately
-    if (url.auth) {
-      this.username = url.auth.split(':')[0];
-      this.password = url.auth.split(':')[1];
-      // set base without auth so request honours our auth options
-      delete url.auth;
-      this.base = urlUtil.format(url);
-      // ensure a "/" hasn't been appended where there wasn't one before
-      if (base[base.length - 1] !== this.base[this.base.length - 1]) {
-        this.base = this.base.slice(0, -1);
-      }
-    }
-  }
+  this.auth = auth;
   this.method = method;
   this.args = args || [];
   this.ctorArgs = ctorArgs || [];
@@ -177,20 +163,23 @@ HttpInvocation.prototype.createRequest = function() {
   var ctorAccepts = null;
   var query;
   var i;
+  var auth = this.auth;
 
   // initial url is the format
   req.url = this.base + method.getFullPath();
 
   // add auth if it is set
-  if (this.username && this.password) {
-    req.auth = {
-      // request defaults to sending auth immidiately, which works for
-      // Basic auth, but doesn't work for Digest auth
-      // Note: these options are ignored if the URL still contains credentials
-      sendImmediately: false,
-      user: this.username,
-      pass: this.password,
-    };
+  if (auth) {
+    req.auth = {};
+    if(auth.username && auth.password) {
+      req.auth.username = auth.username;
+      req.auth.password = auth.password;
+    }
+    if('sendImmediately' in auth) {
+      req.auth.sendImmediately = auth.sendImmediately;
+    } else {
+      req.auth.sendImmediately = false;
+    }
   }
 
   // build request args and method options

--- a/lib/remote-objects.js
+++ b/lib/remote-objects.js
@@ -11,6 +11,7 @@ module.exports = RemoteObjects;
 var EventEmitter = require('eventemitter2').EventEmitter2;
 var debug = require('debug')('strong-remoting:remotes');
 var util = require('util');
+var urlUtil = require('url');
 var inherits = util.inherits;
 var assert = require('assert');
 var Dynamic = require('./dynamic');
@@ -31,6 +32,18 @@ require('./rest-adapter');
  * @param {Object} options
  * @return {RemoteObjects}
  * @class
+ * @property {Object} auth Authentication options used by underlying adapters
+ * to set authorization metadata. **The `rest` adapter supports:**
+ *
+ *  - **basic** - `username` and `password` are required.
+ *  - **digest** - `username` and `password` required and `sendImmediately` must
+ * be false.
+ *  - **bearer** - `bearer` must be set as the bearer token
+ *
+ * @property {String} auth.username
+ * @property {String} auth.password
+ * @property {String} auth.bearer The **bearer token**.
+ * @property {Boolean} auth.sendImmediately Defaults to `false`.
  */
 
 function RemoteObjects(options) {
@@ -89,10 +102,29 @@ RemoteObjects.prototype.handler = function(name, options) {
  */
 
 RemoteObjects.prototype.connect = function(url, name) {
+  // parse URL for auth
+  var urlWithoutAuth = url;
+  var auth;
+
+  var parsedUrl = urlUtil.parse(url);
+  // If base parsedUrl contains auth, extract it so we can set it separately
+  if (parsedUrl.auth) {
+    auth = this.auth = {};
+    auth.username = parsedUrl.auth.split(':')[0];
+    auth.password = parsedUrl.auth.split(':')[1];
+    // set base without auth so request honours our auth options
+    delete parsedUrl.auth;
+    urlWithoutAuth = urlUtil.format(parsedUrl);
+    // ensure a "/" hasn't been appended where there wasn't one before
+    if (url[url.length - 1] !== urlWithoutAuth[urlWithoutAuth.length - 1]) {
+      urlWithoutAuth = urlWithoutAuth.slice(0, -1);
+    }
+  }
+
   var Adapter = this.adapter(name);
   var adapter = new Adapter(this);
   this.serverAdapter = adapter;
-  return adapter.connect(url);
+  return adapter.connect(urlWithoutAuth);
 };
 
 /**

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -113,7 +113,9 @@ RestAdapter.prototype.invoke = function(method, ctorArgs, args, callback) {
 
   var remotes = this.remotes;
   var restMethod = this.getRestMethodByName(method);
-  var invocation = new HttpInvocation(restMethod, ctorArgs, args, this.connection);
+  var invocation = new HttpInvocation(
+    restMethod, ctorArgs, args, this.connection, remotes.auth
+  );
   var ctx = { req: invocation.createRequest() };
   var scope = remotes.getScope(ctx, restMethod);
   remotes.execHooks('before', restMethod, scope, ctx, function(err) {

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -55,6 +55,15 @@ describe('support for HTTP Authentication', function() {
        fails('/digestAuth'));
   });
 
+  describe('remotes.auth', function () {
+    it('should be populated from the url', function () {
+      var url = 'http://login:pass@myhost.com'
+      remotes.connect(url, 'rest');
+      expect(remotes.auth.username).to.eql('login');
+      expect(remotes.auth.password).to.eql('pass');
+    });
+  });
+
   function succeeds(path, credentials) {
     return function(done) {
       invokeRemote(server.address().port, path, credentials,
@@ -77,14 +86,20 @@ describe('support for HTTP Authentication', function() {
   }
 
   function invokeRemote(port, path, credentials, callback) {
-    credentials = credentials || '';
-    if (credentials.length > 0) {
-      credentials += '@';
+    var auth;
+    var split = credentials && credentials.split(':');
+    if(split && split.length === 2) {
+      auth = {
+        username: split[0],
+        password: split[1]
+      }
     }
-    var url = fmt('http://%s127.0.0.1:%d%s', credentials, port, path);
+
+    var url = fmt('http://127.0.0.1:%d%s', port, path);
     var method = 'User.login';
     var args = [{username: 'joe', password: 'secret'}];
     remotes.connect(url, 'rest');
+    remotes.auth = auth;
     remotes.invoke(method, args, callback);
   }
 });


### PR DESCRIPTION
This adds a new feature (built on top of the existing auth support). Using `remotes.auth` you can now provide basic, bearer, and digest authorization (even after `remotes.connect()`).

This patch introduces the api (the `remotes.auth` property) and support in `HttpInvocation`. It maintains backwards compatibility by setting `remotes.auth` using the url provided in `remotes.connect()`.

The key new feature is that authorization can be set at any time and requests afterward will honor this setting. This makes it possible to do this:

```js
remotes.connect('http://localhost:3000');

remotes.invoke('User.login', [{
  username: 'foo',
  password: 'bar'
}], function(err, result) {
  remotes.auth = {
    bearer: result.accessToken
  };
});
```

...all subsequent invocations will be signed with the token.

/to @raymondfeng 
/cc @rmg @bajtos 

Fixes https://github.com/strongloop/strong-remoting/issues/105