### PR TITLE
Preserve non-200 status when no content will be sent

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -381,7 +381,9 @@ HttpContext.prototype.done = function() {
     if (!res.get('Content-Type')) {
       res.header('Content-Type', 'application/json');
     }
-    res.statusCode = 204;
+    if (res.statusCode === undefined || res.statusCode === 200) {
+      res.statusCode = 204;
+    }
     res.end();
   }
 };

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -722,6 +722,25 @@ describe('strong-remoting-rest', function() {
         .expect(204, done);
     });
 
+    it('should preserve non-200 status when responding with no content', function(done) {
+       var method = givenSharedStaticMethod(
+         function(ctx, cb) {
+           ctx.res.status(302);
+           cb();
+         },
+        {
+          accepts: [
+            { arg: 'ctx', type: 'object', http: {source: 'context' } }
+          ],
+        }
+       );
+
+      request(app).get(method.url)
+        .set('Accept', 'application/json')
+        .expect(302, done);
+
+    });
+
     it('should accept custom content-type header if respond with 204', function(done) {
       var method = givenSharedStaticMethod();
       objects.before(method.name, function(ctx, next) {
@@ -1256,6 +1275,7 @@ describe('strong-remoting-rest', function() {
       json(method.url)
         .expect(400, done);
     });
+
   });
 
   describe('call of static method with asynchronous hook', function() {


### PR DESCRIPTION
to / @bajtos -
In reference to
1) Strong-remoting issue - https://github.com/strongloop/strong-remoting/issues/175 , and
2) LB issue - https://github.com/strongloop/loopback/issues/416

I've made changes to retain non-200 status, when no content is sent.

Can you please review?