### PR TITLE
Coerce empty string into empty array with arrayItemDelimiters.

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -199,7 +199,14 @@ SharedMethod.prototype.invoke = function(scope, args, remotingOptions, cb) {
               delims = new RegExp(delims.map(escapeRegex).join('|'), 'g');
               remotingOptions.arrayItemDelimiters = delims;
             }
-            uarg = uarg.split(delims);
+
+            // If we received the empty string (e.g. &arg=), make it an empty
+            // array. Otherwise, the split would turn it into ['']
+            if (uarg.length) {
+              uarg = uarg.split(delims);
+            } else {
+              uarg = [];
+            }
 
             // use for() instead of .map() so that we don't create fns in a loop
             for (var ix in uarg) {

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -907,6 +907,19 @@ describe('strong-remoting-rest', function() {
         .expect({ data: [1, 2, 3] }, done);
     });
 
+    it('should not create empty string array with empty string arg', function(done) {
+      objects.options.rest = { arrayItemDelimiters:  [',', '|'] };
+      var method = givenSharedStaticMethod(
+        function(a, cb) { cb(null, a); },
+        {
+          accepts: { arg: 'a', type: ['number'] },
+          returns: { arg: 'data', type: 'object' }
+        });
+
+      json('post', method.url + '?a=')
+        .expect({ data: [] }, done);
+    });
+
     it('should still support JSON arrays with arrayItemDelimiters', function(done) {
       objects.options.rest = { arrayItemDelimiters:  [',', '|'] };
       var method = givenSharedStaticMethod(


### PR DESCRIPTION
Before this patch, a hit like `GET /endpoint?fooArray=` would, if `arrayItemDelimiters` were used, resolve `fooArray` with the value `['']`.

This is undesirable - I see two options for what an empty value should serialize to for an array arg:

1. `undefined`,
2. `[]`.

I went with `2` because I think `?key=` has a different meaning than `?`, since you might really want to pass the empty array instead of undefined.