### PR TITLE
browser: remove packages used by server only

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
   "browser": {
     "express": false,
     "body-parser": false,
+    "cors": false,
+    "js2xmlparser": false,
     "request": "browser-request"
   },
   "license": {


### PR DESCRIPTION
Remove the following packages:
 - cors
 - js2xmlparser

See https://github.com/strongloop/loopback/issues/989

/to @ritch please review
/cc @BerkeleyTrue 