### PR TITLE
Implement "afterError" hook

### DIFF
--- a/lib/remote-objects.js
+++ b/lib/remote-objects.js
@@ -325,6 +325,50 @@ RemoteObjects.prototype.after = function(methodMatch, fn) {
   this.on('after.' + methodMatch, fn);
 };
 
+/**
+ * Execute the given `hook` function after the method matched by the method
+ * string failed.
+ *
+ * **Examples:**
+ *
+ * ```js
+ * // Do something after the `speak` instance method failed.
+ * remotes.afterError('dog.prototype.speak', function(ctx, next) {
+ *   console.log('Cannot speak!', ctx.error);
+ *   next();
+ * });
+ *
+ * // Do something before all methods.
+ * remotes.afterError('**', function(ctx, next, method) {
+ *   console.log('Failed', method.name, ctx.error);
+ *   next();
+ * });
+ *
+ * // Modify all returned errors
+ * remotes.after('**', function(ctx, next) {
+ *   if (!ctx.error.details) ctx.result.details = {};
+ *   ctx.error.details.info = 'intercepted by a hook';
+ *   next();
+ * });
+ *
+ * // Report a different error
+ * remotes.after('dog.prototype.speak', function(ctx, next) {
+ *   console.error(ctx.error);
+ *   next(new Error('See server console log for details.'));
+ * });
+ * ```
+ *
+ * @param {String} methodMatch The glob to match a method string
+ * @callback {Function} hook
+ * @param {Context} ctx The adapter specific context
+ * @param {Function} next Call with an optional error object
+ * @param {SharedMethod} method The SharedMethod object
+ */
+
+RemoteObjects.prototype.afterError = function(methodMatch, fn) {
+  this.on('afterError.' + methodMatch, fn);
+};
+
 /*!
  * Create a middleware style emit that supports wildcards.
  */
@@ -546,17 +590,25 @@ RemoteObjects.prototype.invokeMethodInContext = function(ctx, method, cb) {
   var scope = this.getScope(ctx, method);
 
   self.execHooks('before', method, scope, ctx, function(err) {
-    if (err) return cb(err);
+    if (err) return triggerErrorAndCallBack(err);
 
     ctx.invoke(scope, method, function(err, result) {
-      if (err) return cb(err);
+      if (err) return triggerErrorAndCallBack(err);
+
       ctx.result = result;
       self.execHooks('after', method, scope, ctx, function(err) {
-        if (err) return cb(err);
+        if (err) return triggerErrorAndCallBack(err);
         cb();
       });
     });
   });
+
+  function triggerErrorAndCallBack(err) {
+    ctx.error = err;
+    self.execHooks('afterError', method, scope, ctx, function(hookErr) {
+      cb(hookErr || err);
+    });
+  }
 };
 
 /**


### PR DESCRIPTION
Example usage:

    // Do something after the `speak` instance method failed.
    remotes.afterError('dog.prototype.speak', function(ctx, next) {
      console.log('Cannot speak!', ctx.error);
      next();
    });

    // Modify all returned errors
    remotes.after('**', function(ctx, next) {
      ie (!ctx.error.details) ctx.result.details = {};
      ctx.error.details.info = 'intercepted by a hook';
      next();
    });

    // Report a different error
    remotes.after('dog.prototype.speak', function(ctx, next) {
      console.error(ctx.error);
      next(new Error('See server console log for details.'));
    });

Connect to #189 

/to @ritch please review
/cc @raymondfeng @fabien 