### PR TITLE
Forward invocation error details

### DIFF
--- a/lib/http-invocation.js
+++ b/lib/http-invocation.js
@@ -264,11 +264,13 @@ HttpInvocation.prototype.transformResponse = function(res, body, callback) {
   if (hasError) {
     if (isObject && body.error) {
       err = new Error(body.error.message);
-      err.name = body.error.name;
-      err.stack = body.error.stack;
-      err.details = body.error.details;
+      for (var key in body.error) {
+        err[key] = body.error[key];
+      }
     } else {
       err = new Error('Error: ' + res.statusCode);
+      err.statusCode = res.statusCode;
+      err.details = body;
     }
 
     return callback(err);

--- a/test/http-invocation.test.js
+++ b/test/http-invocation.test.js
@@ -131,6 +131,55 @@ describe('HttpInvocation', function() {
         this.foo = data.foo;
       }
     });
+
+    it('should forward all error properties', function(done) {
+      var method = givenSharedStaticMethod({});
+      var inv = new HttpInvocation(method);
+      var res = {
+        statusCode: 555,
+        body: {
+          error: {
+            name: 'CustomError',
+            message: 'Custom error message',
+            statusCode: 555,
+            details: {
+              key: 'value'
+            },
+            extra: 'extra value'
+          }
+        }
+      };
+
+      inv.transformResponse(res, res.body, function(err) {
+        if (!err)
+          return done(new Error('transformResponse should have failed.'));
+
+        expect(err).to.have.property('name', 'CustomError');
+        expect(err).to.have.property('message', 'Custom error message');
+        expect(err).to.have.property('statusCode', 555);
+        expect(err).to.have.property('details').eql({ key: 'value' });
+        expect(err).to.have.property('extra', 'extra value');
+        done();
+      });
+    });
+
+    it('should forward statusCode and non-object error response', function(done) {
+      var method = givenSharedStaticMethod({});
+      var inv = new HttpInvocation(method);
+      var res = {
+        statusCode: 555,
+        body: 'error body'
+      };
+
+      inv.transformResponse(res, res.body, function(err) {
+        if (!err)
+          return done(new Error('transformResponse should have failed.'));
+
+        expect(err).to.have.property('statusCode', 555);
+        expect(err).to.have.property('details', 'error body');
+        done();
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Most notably always set `err.statusCode`.

Connect to strongloop/loopback#1166

/to @ritch please review