### PR TITLE
REST: store model, method and ctorArgs on ctx.req

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -45,6 +45,8 @@ function HttpContext(req, res, method, options) {
       return !/\bxml\b/i.test(type);
     });
   }
+
+  this._exposeRequestMeta();
 }
 
 /**
@@ -52,6 +54,26 @@ function HttpContext(req, res, method, options) {
  */
 
 inherits(HttpContext, EventEmitter);
+
+HttpContext.prototype._exposeRequestMeta = function() {
+  var method = this.method;
+  var req = this.req;
+  req.remoteMethod = (method.isStatic ? '' : 'prototype.') + method.name;
+  req.remoteClass = method.sharedClass && method.sharedClass.name;
+
+  if (!method.sharedCtor) return;
+
+  var ctorAccepts = method.sharedCtor.accepts;
+  if (ctorAccepts && !Array.isArray(ctorAccepts))
+    ctorAccepts = [ctorAccepts];
+
+  req.remoteInstance = {};
+  var requestArgs = this.args;
+  ctorAccepts.forEach(function(arg) {
+    var key = arg.name || arg.arg;
+    req.remoteInstance[key] = requestArgs[key];
+  });
+};
 
 /**
  * Build args object from the http context's `req` and `res`.
@@ -250,6 +272,7 @@ HttpContext.prototype.invoke = function(scope, method, fn, isCtor) {
     if (args === undefined) {
       return;
     }
+    this.req.remoteInstance = args;
   }
   var http = method.http;
   var pipe = http && http.pipe;

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -11,7 +11,6 @@ var Promise = global.Promise || require('bluebird');
 var ACCEPT_XML_OR_ANY = 'application/xml,*/*;q=0.8';
 var TEST_ERROR = new Error('expected test error');
 
-
 describe('strong-remoting-rest', function() {
   var app;
   var appSupportingJsonOnly;
@@ -2183,7 +2182,7 @@ describe('strong-remoting-rest', function() {
 
       objects.afterError(method.name, function(ctx, next) {
         if (Array.isArray(hookContext)) {
-          hookContext.push(context);
+          hookContext.push(hookContext);
         } else if (typeof hookContext === 'object') {
           hookContext = [hookContext, ctx];
         } else {


### PR DESCRIPTION
Modify the http-context (used e.g. by the rest-adapter) to expose additional metadata on the `req` object:

    req.remoteClass = name of the remote class (the LoopBack model)
    req.remoteMethod = name of the method invoked
    req.remoteInstance = arguments for the shared constructor

Examples:

    POST /api/Cars
      remoteClass: Car
      remoteMethod: create
      remoteInstance: { id: undefined }

    PUT /api/Cars/123
      remoteClass: Car
      remoteMethod: prototype.updateOrCreate
      remoteInstance: { id: '123' }

    GET /api/Cars/123
      remoteClass: Car
      remoteMethod: findById
      remoteInstance: { id: '123' }

Connect to strongloop/loopback#1276

In the next step, I'll modify strong-express-metrics to detect these three new request properties and include them in all metrics records.

/to @ritch please review
/cc @altsang @anthonyettinger PTAL too, to make sure this is in line with your requirements.