### PR TITLE
http-context: save "ctorArgs" on the context

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -248,7 +248,7 @@ function buildArgs(ctx, method, fn) {
 HttpContext.prototype.invoke = function(scope, method, fn, isCtor) {
   var args = this.args;
   if (isCtor) {
-    args = buildArgs(this, method, fn);
+    args = this.ctorArgs = buildArgs(this, method, fn);
     if (args === undefined) {
       return;
     }

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -1619,6 +1619,17 @@ describe('strong-remoting-rest', function() {
         done();
       });
     });
+
+    it('should set "remotingContext.ctorArgs"', function(done) {
+      var method = givenSharedPrototypeMethod();
+      json(method.getUrlForId(1234)).end(function(err) {
+        if (err) return done(err);
+        expect(lastRequest)
+          .to.have.deep.property('remotingContext.ctorArgs.id', 1234);
+        // Notice that the id was correctly coerced to a Number ^^^^
+        done();
+      });
+    });
   });
 
   it('returns 404 for unknown method of a shared class', function(done) {


### PR DESCRIPTION
Set "ctx.ctorArgs" to the arguments passed to a constructor method.

Connect to strongloop/loopback#1276

/to @ritch please review.

I need this change in order to obtain the instance id in strong-express-metrics via `req.remotingContext.ctorArgs.id`