### PR TITLE
Enable Travis CI for this project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "0.10"
+  - "0.12"
+  - "iojs"
+


### PR DESCRIPTION
Based on the discussion in #195, I would like to enable Travis CI for this project.

Benefits:

 - Anonymous access to build results - contributors see why their pull request failed the build
 - The build fails whenever `npm build` fails. This allows us to control the acceptance criteria, most notably the build will fail on linter errors.

Close #195

/to @ritch please review
/cc @rmg @raymondfeng @STRML 