### PR TITLE
Fix array coercion for non-array target type

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -236,23 +236,24 @@ function escapeRegex(d) {
  * @return {*}                 Coerced argument.
  */
 function coerceAccepts(uarg, desc) {
-  // If array, invoke for each member of the array.
-  if (Array.isArray(uarg)) {
-    return uarg.map(function(arg) {
-      return coerceAccepts(arg, desc);
+  var name = desc.name || desc.arg;
+  var targetType = desc.type;
+  var targetIsArray = Array.isArray(targetType) && targetType.length === 1;
+
+  // If coercing an array to an erray,
+  // then coerce all members of the array too
+  if (targetIsArray && Array.isArray(uarg)) {
+    return uarg.map(function(arg, ix) {
+      // when coercing array items, use only name and type,
+      // ignore all other root settings like "required"
+      return coerceAccepts(arg, {
+        name: name + '[' + ix +']',
+        type: desc.type[0]
+      });
     });
   }
 
-  var name = desc.name || desc.arg;
-  var targetType = desc.type;
   var actualType = SharedMethod.getType(uarg);
-
-  // Target type may be an array. If so, expect the arg to be a member of that array,
-  // since we map this function over arrays.
-  var targetIsArray = Array.isArray(targetType) && targetType.length === 1;
-  if (targetIsArray) {
-    targetType = targetType[0];
-  }
 
   // is the arg optional?
   // arg was not provided

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -994,6 +994,37 @@ describe('strong-remoting-rest', function() {
         });
     });
 
+    it('should not flatten arrays for non-standard target type', function(done) {
+      var method = givenSharedStaticMethod(
+        function(arg, cb) { cb(null, { value: arg }); },
+        {
+          // Note: the string "array" is not a valid type
+          accepts: { arg: 'arg', type: 'array' },
+          returns: { arg: 'data', type: 'any', root: true },
+          http: { method: 'POST' }
+        });
+
+      request(app).post(method.url)
+        .send({ arg: ['single'] })
+        .expect(200, { value: ['single'] })
+        .end(done);
+    });
+
+    it('should not flatten arrays for target type "object"', function(done) {
+      var method = givenSharedStaticMethod(
+        function(arg, cb) { cb(null, { value: arg }); },
+        {
+          accepts: { arg: 'arg', type: 'object' },
+          returns: { arg: 'data', type: 'any', root: true },
+          http: { method: 'POST' }
+        });
+
+      request(app).post(method.url)
+        .send({ arg: ['single'] })
+        .expect(200, { value: ['single'] })
+        .end(done);
+    });
+
     it('should allow empty body for json request', function(done) {
       remotes.foo = {
         bar: function(a, b, fn) {


### PR DESCRIPTION
Before this patch, when sending an array to an argument of type "object" or "any", the value was flattened and the first item was used instead of the array.

This patch fixes the issue by omitting recursive coersion when the target type is not an array.

See #196 that introduced the regression.

/to @ritch please review
/cc @STRML @XinV