### PR TITLE
Cleanup in coercion code

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -238,11 +238,11 @@ function escapeRegex(d) {
 function coerceAccepts(uarg, desc) {
   var name = desc.name || desc.arg;
   var targetType = convertToBasicRemotingType(desc.type);
-  var targetIsArray = Array.isArray(targetType) && targetType.length === 1;
+  var targetTypeIsArray = Array.isArray(targetType) && targetType.length === 1;
 
   // If coercing an array to an erray,
   // then coerce all members of the array too
-  if (targetIsArray && Array.isArray(uarg)) {
+  if (targetTypeIsArray && Array.isArray(uarg)) {
     return uarg.map(function(arg, ix) {
       // when coercing array items, use only name and type,
       // ignore all other root settings like "required"

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -994,12 +994,11 @@ describe('strong-remoting-rest', function() {
         });
     });
 
-    it('should not flatten arrays for non-standard target type', function(done) {
+    it('should not flatten arrays for target type "any"', function(done) {
       var method = givenSharedStaticMethod(
         function(arg, cb) { cb(null, { value: arg }); },
         {
-          // Note: the string "array" is not a valid type
-          accepts: { arg: 'arg', type: 'array' },
+          accepts: { arg: 'arg', type: 'any' },
           returns: { arg: 'data', type: 'any', root: true },
           http: { method: 'POST' }
         });


### PR DESCRIPTION
 - Use "any" instead of "array" in the unit test to make it easier
   to understand what's happening under the hood.

 - Rename "targetIsArray" to "targetTypeIsArray".

This is a follow-up for #204.

/to @ritch please review
/cc @STRML 