### PR TITLE
Tighten coercion and type checks in SharedMethod

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -237,7 +237,7 @@ function escapeRegex(d) {
  */
 function coerceAccepts(uarg, desc) {
   var name = desc.name || desc.arg;
-  var targetType = desc.type;
+  var targetType = convertToBasicRemotingType(desc.type);
   var targetIsArray = Array.isArray(targetType) && targetType.length === 1;
 
   // If coercing an array to an erray,
@@ -306,6 +306,39 @@ function coerceAccepts(uarg, desc) {
   }
 
   return uarg;
+}
+
+/**
+ * Returns an appropriate type based on a type specifier from remoting
+ * metadata.
+ * @param {Object} type A type specifier from remoting metadata,
+ *    e.g. "[Number]" or "MyModel" from `accepts[0].type`.
+ * @returns {String} A type name compatible with the values returned by
+ *   `SharedMethod.getType()`, e.g. "string" or "array".
+ */
+function convertToBasicRemotingType(type) {
+  if (Array.isArray(type)) {
+    return type.map(convertToBasicRemotingType);
+  }
+
+  if (typeof type === 'object') {
+    type = type.modelName || type.name;
+  }
+
+  type = String(type).toLowerCase();
+  switch (type) {
+    case 'string':
+    case 'number':
+    case 'date':
+    case 'boolean':
+    case 'buffer':
+    case 'object':
+    case 'any':
+      return type;
+    default:
+      // custom types like MyModel
+      return 'object';
+  }
 }
 
 function convertValueToTargetType(argName, value, targetType) {

--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -247,7 +247,7 @@ function coerceAccepts(uarg, desc) {
       // when coercing array items, use only name and type,
       // ignore all other root settings like "required"
       return coerceAccepts(arg, {
-        name: name + '[' + ix +']',
+        name: name + '[' + ix + ']',
         type: desc.type[0]
       });
     });
@@ -255,8 +255,44 @@ function coerceAccepts(uarg, desc) {
 
   var actualType = SharedMethod.getType(uarg);
 
-  // is the arg optional?
-  // arg was not provided
+  // convert values to the correct type
+  // TODO(bajtos) Move conversions to HttpContext (and friends)
+  // SharedMethod should only check that argument values match argument types.
+  var conversionNeeded = targetType !== 'any' &&
+    actualType !== 'undefined' &&
+    actualType !== targetType;
+
+  if (conversionNeeded) {
+    // JSON.parse can throw, so catch this error.
+    try {
+      uarg = convertValueToTargetType(name, uarg, targetType);
+      actualType = SharedMethod.getType(uarg);
+    } catch (e) {
+      var message = util.format('invalid value for argument \'%s\' of type ' +
+        '\'%s\': %s. Received type was %s. Error: %s',
+        name, targetType, uarg, typeof uarg, e.message);
+      throw new badArgumentError(message);
+    }
+  }
+
+  var typeMismatch = targetType !== 'any' &&
+    actualType !== 'undefined' &&
+    targetType !== actualType &&
+    // In JavaScript, an array is an object too (typeof [] === 'object').
+    // However, SharedMethod.getType([]) returns 'array' instead of 'object'.
+    // We must explicitly allow assignment of an array value to an argument
+    // of type 'object'.
+    !(targetType === 'object' && actualType === 'array');
+
+  if (typeMismatch) {
+    var message = util.format('Invalid value for argument \'%s\' of type ' +
+      '\'%s\': %s. Received type was converted to %s.',
+      name, targetType, uarg, typeof uarg);
+    throw new badArgumentError(message);
+  }
+
+  // Verify that a required argument has a value
+  // FIXME(bajtos) "null" should be treated as no value too
   if (actualType === 'undefined') {
     if (desc.required) {
       throw new badArgumentError(name + ' is a required arg');
@@ -269,35 +305,30 @@ function coerceAccepts(uarg, desc) {
     throw new badArgumentError(name + ' must be a number');
   }
 
-  // convert strings
-  if (actualType === 'string' && targetType !== 'any' && actualType !== targetType) {
-    // JSON.parse can throw, so catch this error.
-    try {
-      uarg = convertValueToTargetType(uarg, targetType);
-    } catch (e) {
-      var message = util.format('invalid value for argument \'%s\' of type ' +
-        '\'%s\': %s. Received type was %s. Error: %s',
-        name, targetType, uarg, typeof uarg, e.message);
-      throw new badArgumentError(message);
-    }
-  }
   return uarg;
 }
 
-function convertValueToTargetType(value, targetType) {
+function convertValueToTargetType(argName, value, targetType) {
   switch (targetType) {
     case 'string':
-      return value;
+      return String(value).valueOf();
     case 'date':
       return new Date(value);
     case 'number':
-      return Number(value);
+      return Number(value).valueOf();
     case 'boolean':
-      return Boolean(value);
+      return Boolean(value).valueOf();
     // Other types such as 'object', 'array',
     // ModelClass, ['string'], or [ModelClass]
     default:
-      return JSON.parse(value);
+      switch (typeof value) {
+        case 'string':
+          return JSON.parse(value);
+        case 'object':
+          return value;
+        default:
+          throw new badArgumentError(argName + ' must be ' + targetType);
+      }
   }
 }
 

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -1798,6 +1798,33 @@ describe('strong-remoting-rest', function() {
       });
   });
 
+  it('coerces array values passed to a string argument', function(done) {
+    var method = givenSharedStaticMethod(
+      function(arg, cb) { cb(null, arg); },
+      {
+        accepts: { arg: 'arg', type: 'string' },
+        returns: { arg: 'arg', type: 'string' }
+      });
+
+    request(app).get(method.url + '?arg=1&arg=2')
+      .expect(200)
+      .end(function(err, res) {
+        if (err) return done(err);
+        expect(res.body.arg).to.eql('1,2');
+        done();
+      });
+  });
+
+  it('rejects multi-item array passed to a number argument', function(done) {
+    var method = givenSharedStaticMethod(
+      function(arg, cb) { cb(); },
+      { accepts: { arg: 'arg', type: 'number' }});
+
+    request(app).get(method.url + '?arg=1&arg=2')
+      .expect(400)
+      .end(done);
+  });
+
   describe('client', function() {
 
     describe('call of constructor method', function() {

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -1825,6 +1825,28 @@ describe('strong-remoting-rest', function() {
       .end(done);
   });
 
+  it('supports "Object" type string', function(done) {
+    var method = givenSharedStaticMethod(
+      function(arg, cb) { cb(); },
+      { accepts: { arg: 'arg', type: 'Object' }});
+
+    request(app)
+      .get(method.url + '?arg={"x":1}')
+      .expect(204)
+      .end(done);
+  });
+
+  it('supports custom type string', function(done) {
+    var method = givenSharedStaticMethod(
+      function(arg, cb) { cb(); },
+      { accepts: { arg: 'arg', type: 'Model' } });
+
+    request(app)
+      .get(method.url + '?arg={"x":1}')
+      .expect(204)
+      .end(done);
+  });
+
   describe('client', function() {
 
     describe('call of constructor method', function() {

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -1814,6 +1814,7 @@ describe('strong-remoting-rest', function() {
 
         var msg = 'hello';
         objects.invoke(method.name, [msg], function(err, resMsg) {
+          if (err) return done(err);
           assert.equal(resMsg, msg);
           done();
         });
@@ -1835,6 +1836,7 @@ describe('strong-remoting-rest', function() {
         );
 
         objects.invoke(method.name, [1, 2], function(err, n) {
+          if (err) return done(err);
           assert.equal(n, 3);
           done();
         });
@@ -1856,6 +1858,7 @@ describe('strong-remoting-rest', function() {
         );
 
         objects.invoke(method.name, [1, 2], function(err, n) {
+          if (err) return done(err);
           assert.equal(n, 3);
           done();
         });
@@ -1877,6 +1880,7 @@ describe('strong-remoting-rest', function() {
         );
 
         objects.invoke(method.name, [], function(err) {
+          if (err) return done(err);
           assert(called);
           done();
         });
@@ -1901,6 +1905,7 @@ describe('strong-remoting-rest', function() {
         };
 
         objects.invoke(method.name, [obj], function(err, data) {
+          if (err) return done(err);
           expect(obj).to.deep.equal(data);
           done();
         });
@@ -1922,6 +1927,7 @@ describe('strong-remoting-rest', function() {
 
         var data = {date: {$type: 'date', $data: new Date()}};
         objects.invoke(method.name, [data], function(err, resData) {
+          if (err) return done(err);
           expect(resData).to.deep.equal({date: data.date.$data.toISOString()});
           done();
         });
@@ -1943,6 +1949,7 @@ describe('strong-remoting-rest', function() {
         );
 
         objects.invoke(method.name, [1, 2], function(err, n) {
+          if (err) return done(err);
           assert.equal(n, 3);
           done();
         });
@@ -1966,6 +1973,7 @@ describe('strong-remoting-rest', function() {
         );
 
         objects.invoke(method.name, [1, 2], function(err, a, b) {
+          if (err) return done(err);
           assert.equal(a, 1);
           assert.equal(b, 2);
           done();
@@ -2004,6 +2012,7 @@ describe('strong-remoting-rest', function() {
 
         var msg = 'hello';
         objects.invoke(method.name, ['anId'], [msg], function(err, resMsg) {
+          if (err) return done(err);
           assert.equal(resMsg, 'anId:' + msg);
           done();
         });
@@ -2025,6 +2034,7 @@ describe('strong-remoting-rest', function() {
         );
 
         objects.invoke(method.name, [39], [1, 2], function(err, n) {
+          if (err) return done(err);
           assert.equal(n, 42);
           done();
         });
@@ -2046,6 +2056,7 @@ describe('strong-remoting-rest', function() {
         );
 
         objects.invoke(method.name, [39], [1, 2], function(err, n) {
+          if (err) return done(err);
           assert.equal(n, 42);
           done();
         });
@@ -2067,6 +2078,7 @@ describe('strong-remoting-rest', function() {
         );
 
         objects.invoke(method.name, [39], [], function(err) {
+          if (err) return done(err);
           assert(called);
           done();
         });
@@ -2091,6 +2103,7 @@ describe('strong-remoting-rest', function() {
         };
 
         objects.invoke(method.name, [39], [obj], function(err, data) {
+          if (err) return done(err);
           expect(obj).to.deep.equal(data);
           done();
         });
@@ -2112,6 +2125,7 @@ describe('strong-remoting-rest', function() {
 
         var data = {date: {$type: 'date', $data: new Date()}};
         objects.invoke(method.name, [39], [data], function(err, resData) {
+          if (err) return done(err);
           expect(resData).to.deep.equal({date: data.date.$data.toISOString()});
           done();
         });
@@ -2133,6 +2147,7 @@ describe('strong-remoting-rest', function() {
         );
 
         objects.invoke(method.name, [39], [1, 2], function(err, n) {
+          if (err) return done(err);
           assert.equal(n, 42);
           done();
         });
@@ -2157,6 +2172,7 @@ describe('strong-remoting-rest', function() {
         );
 
         objects.invoke(method.name, ['39'], [1, 2], function(err, id, a, b) {
+          if (err) return done(err);
           assert.equal(id, '39');
           assert.equal(a, 1);
           assert.equal(b, 2);


### PR DESCRIPTION
- Modify `coerceAccepts()` to be more strict about the argument value matching the requested argument type.

- Modify the converter to return primitive types (e.g. "number 3") instead of object types (e.g. "Number(3)").

- Reject argument values that don't match target type even after the conversion was applied (HTTP status code 400 is returned in such case).

- Improve test failure messages by reporting errors from `object.invoke()` instead of failing on an assertion that expected successful invocation.

Connect to strongloop-internal/scrum-loopback#243

/to @ritch @raymondfeng please review
/cc @STRML 