### PR TITLE
add test to verify target type array

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -257,7 +257,7 @@ function coerceAccepts(uarg, desc) {
       // ignore all other root settings like "required"
       return coerceAccepts(arg, {
         name: name + '[' + ix + ']',
-        type: desc.type[0]
+        type: targetType[0]
       });
     });
   }
@@ -335,6 +335,7 @@ function convertToBasicRemotingType(type) {
   }
 
   type = String(type).toLowerCase();
+
   switch (type) {
     case 'string':
     case 'number':
@@ -344,6 +345,8 @@ function convertToBasicRemotingType(type) {
     case 'object':
     case 'any':
       return type;
+    case 'array':
+      return ['any'].map(convertToBasicRemotingType);
     default:
       // custom types like MyModel
       return 'object';

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -1024,6 +1024,66 @@ describe('strong-remoting-rest', function() {
         .end(done);
     });
 
+    it('should support taget type [any]', function(done) {
+      var method = givenSharedStaticMethod(
+        function(arg, cb) { cb(null, { value: arg }); },
+        {
+          accepts: { arg: 'arg', type: ['any'] },
+          returns: { arg: 'data', type: ['any'], root: true },
+          http: { method: 'POST' }
+        });
+
+      request(app).post(method.url)
+        .send({ arg: ['single'] })
+        .expect(200, { value: ['single'] })
+        .end(done);
+    });
+
+    it('should support taget type `array` - of string', function(done) {
+      var method = givenSharedStaticMethod(
+        function(arg, cb) { cb(null, { value: arg }); },
+        {
+          accepts: { arg: 'arg', type: 'array' },
+          returns: { arg: 'data', type: 'array', root: true },
+          http: { method: 'POST' }
+        });
+
+      request(app).post(method.url)
+        .send({ arg: ['single'] })
+        .expect(200, { value: ['single'] })
+        .end(done);
+    });
+
+    it('should support taget type `array` - of number', function(done) {
+      var method = givenSharedStaticMethod(
+        function(arg, cb) { cb(null, { value: arg }); },
+        {
+          accepts: { arg: 'arg', type: 'array' },
+          returns: { arg: 'data', type: 'array', root: true },
+          http: { method: 'POST' }
+        });
+
+      request(app).post(method.url)
+        .send({ arg: [1] })
+        .expect(200, { value: [1] })
+        .end(done);
+    });
+
+    it('should support taget type `array` - of object', function(done) {
+      var method = givenSharedStaticMethod(
+        function(arg, cb) { cb(null, { value: arg }); },
+        {
+          accepts: { arg: 'arg', type: 'array' },
+          returns: { arg: 'data', type: 'array', root: true },
+          http: { method: 'POST' }
+        });
+
+      request(app).post(method.url)
+        .send({ arg: [{foo: 'bar'}] })
+        .expect(200, { value: [{foo: 'bar'}] })
+        .end(done);
+    });
+
     it('should allow empty body for json request', function(done) {
       remotes.foo = {
         bar: function(a, b, fn) {


### PR DESCRIPTION
@bajtos, 
In reference to https://github.com/strongloop/loopback/issues/1327, ```accepts: { arg: 'arg', type: 'array' }```, worked out of the box, without me requiring to make any changes!

I've just added test cases to verify target type ```array```

Can you please review?