### PR TITLE
Support arg type "array"

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -102,14 +102,23 @@ function SharedMethod(fn, name, sc, options) {
   if (this.accepts && !Array.isArray(this.accepts)) {
     this.accepts = [this.accepts];
   }
+  this.accepts.forEach(normalizeArgumentDescriptor);
+
   if (this.returns && !Array.isArray(this.returns)) {
     this.returns = [this.returns];
   }
+  this.returns.forEach(normalizeArgumentDescriptor);
+
   if (this.errors && !Array.isArray(this.errors)) {
     this.errors = [this.errors];
   }
 
   this.stringName = (sc ? sc.name : '') + (isStatic ? '.' : '.prototype.') + name;
+}
+
+function normalizeArgumentDescriptor(desc) {
+  if (desc.type === 'array')
+    desc.type = ['any'];
 }
 
 /**

--- a/test/shared-method.test.js
+++ b/test/shared-method.test.js
@@ -6,6 +6,31 @@ var factory = require('./helpers/shared-objects-factory.js');
 var Promise = global.Promise || require('bluebird');
 
 describe('SharedMethod', function() {
+  var STUB_CLASS = {};
+  var STUB_METHOD = function(cb) { cb(); };
+
+  describe('constructor', function() {
+    it('normalizes "array" type in "accepts" arguments', function() {
+      var sharedMethod = new SharedMethod(STUB_METHOD, 'a-name', STUB_CLASS, {
+        accepts: { arg: 'data', type: 'array' }
+      });
+
+      expect(sharedMethod.accepts).to.eql([
+        { arg: 'data', type: ['any'] }
+      ]);
+    });
+
+    it('normalizes "array" type in "returns" arguments', function() {
+      var sharedMethod = new SharedMethod(STUB_METHOD, 'a-name', STUB_CLASS, {
+        returns: { arg: 'data', type: 'array' }
+      });
+
+      expect(sharedMethod.returns).to.eql([
+        { arg: 'data', type: ['any'] }
+      ]);
+    });
+  });
+
   describe('sharedMethod.isDelegateFor(suspect, [isStatic])', function() {
 
     // stub function


### PR DESCRIPTION
Support `type: 'array'` as a syntactic sugar for `type: ['any']`.

Connect to strongloop/loopback#1327
See also #209 

/to @ritch please review
/cc @PradnyaBaviskar @fabien 