### PR TITLE
Add authorization hook

### DIFF
--- a/lib/remote-objects.js
+++ b/lib/remote-objects.js
@@ -577,6 +577,16 @@ function searchListenerTree(handlers, type, tree, i) {
   return listeners;
 }
 
+RemoteObjects.prototype._executeAuthorizationHook = function(ctx, cb) {
+  if (typeof this.authorization === 'function') {
+    this.authorization(ctx, cb);
+  } else {
+    process.nextTick(function() {
+      cb();
+    });
+  }
+};
+
 /**
  * Invoke the given shared method using the supplied context.
  * Execute registered before/after hooks.
@@ -589,16 +599,20 @@ RemoteObjects.prototype.invokeMethodInContext = function(ctx, method, cb) {
 
   var scope = this.getScope(ctx, method);
 
-  self.execHooks('before', method, scope, ctx, function(err) {
+  self._executeAuthorizationHook(ctx, function(err) {
     if (err) return triggerErrorAndCallBack(err);
 
-    ctx.invoke(scope, method, function(err, result) {
+    self.execHooks('before', method, scope, ctx, function(err) {
       if (err) return triggerErrorAndCallBack(err);
 
-      ctx.result = result;
-      self.execHooks('after', method, scope, ctx, function(err) {
+      ctx.invoke(scope, method, function(err, result) {
         if (err) return triggerErrorAndCallBack(err);
-        cb();
+
+        ctx.result = result;
+        self.execHooks('after', method, scope, ctx, function(err) {
+          if (err) return triggerErrorAndCallBack(err);
+          cb();
+        });
       });
     });
   });

--- a/test/authorize-hook.test.js
+++ b/test/authorize-hook.test.js
@@ -1,0 +1,58 @@
+var expect = require('chai').expect;
+var express = require('express');
+var RemoteObjects = require('../');
+var User = require('./e2e/fixtures/user');
+var fmt = require('util').format;
+var User = require('./e2e/fixtures/user');
+
+describe('authorization hook', function() {
+  var server;
+  var remotes;
+
+  before(function setupServer(done) {
+    var app = express();
+    remotes = RemoteObjects.create();
+    remotes.exports.User = User;
+    app.use(remotes.handler('rest'));
+    server = app.listen(0, '127.0.0.1', done);
+  });
+
+  after(function teardownServer(done) {
+    server.close(done);
+  });
+
+  describe('given a remotes object with an authorization hook', function() {
+    it('should be called when a remote method is invoked', function(done) {
+      var callStack = [];
+      remotes.authorization = function(ctx, next) {
+        callStack.push('authorization');
+        next();
+      };
+
+      remotes.before('User.login', function(ctx, next) {
+        callStack.push('before');
+        next();
+      });
+
+      invokeRemote(server.address().port,
+        function(err, session) {
+          expect(err).to.not.exist();
+          expect(session.userId).to.equal(123);
+          //                        vvvvvvvv - local before hook
+          expect(callStack).to.eql(['before', 'authorization', 'before']);
+          done();
+        }
+      );
+    });
+  });
+
+  function invokeRemote(port, callback) {
+    var url = 'http://127.0.0.1:' + port;
+    var method = 'User.login';
+    var args = [{username: 'joe', password: 'secret'}];
+
+    remotes.connect(url, 'rest');
+    remotes.invoke(method, args, callback);
+  }
+});
+


### PR DESCRIPTION
/to @raymondfeng 
/cc @fabien @bajtos 

This pull request adds a new hook that is executed in the following order:

1. invokeMethodInContext
2. **authorization hook**
3. before hooks
4. method
5. after hooks

Here is a basic example implementing the hook:

```js
remotes.authorization = function(ctx, next) {
  // you must callback with an error to cancel the invokation
  next(new Error('denied'));
}
```