### PR TITLE
Add object mode ReadableStream support

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -23,6 +23,7 @@ var DEFAULT_SUPPORTED_TYPES = [
   ];
 
 var MuxDemux = require('mux-demux');
+var SSEClient = require('sse').Client;
 
 /**
  * Create a new `HttpContext` with the given `options`.
@@ -41,6 +42,10 @@ function HttpContext(req, res, method, options) {
   this.methodString = method.stringName;
   this.supportedTypes = this.options.supportedTypes || DEFAULT_SUPPORTED_TYPES;
   this.result = {};
+
+  var streamsDesc = method.streams;
+  var returnStreamDesc = streamsDesc && streamsDesc.returns;
+  var methodReturnsStream = !!returnStreamDesc;
 
   if (this.supportedTypes === DEFAULT_SUPPORTED_TYPES && !this.options.xml) {
     // Disable all XML-based types by default
@@ -64,18 +69,26 @@ function HttpContext(req, res, method, options) {
 inherits(HttpContext, EventEmitter);
 
 HttpContext.prototype.createStream = function() {
-  var streamDesc = this.method.stream;
+  var streamsDesc = this.method.streams;
+  var returnStreamDesc = streamsDesc && streamsDesc.returns;
   var mdm = this.muxDemuxStream = new MuxDemux();
   var io = this.io = {};
   var res = this.res;
 
   debug('create stream');
 
-  if (streamDesc.json && streamDesc.type === 'ReadableStream') {
-    this.io.out = mdm.createWriteStream();
-    // since the method returns a ReadableStream
-    // setup an output to pipe the ReadableStream to
-    mdm.pipe(res);
+  if (returnStreamDesc.json && returnStreamDesc.type === 'ReadableStream') {
+
+    if (!this.shouldReturnEventStream()) {
+      res.setHeader('Content-Type',
+      returnStreamDesc.contentType || 'application/json; boundary=NL');
+      res.setHeader('Transfer-Encoding', 'chunked');
+
+      this.io.out = mdm.createWriteStream();
+      // since the method returns a ReadableStream
+      // setup an output to pipe the ReadableStream to
+      mdm.pipe(res);
+    }
   }
 };
 
@@ -436,29 +449,66 @@ function toXML(input) {
   }
   return xml;
 }
+
+HttpContext.prototype.shouldReturnEventStream = function() {
+  var req = this.req;
+  var query = req.query;
+  var format = query._format;
+
+  var acceptable = req.accepts('text/event-stream');
+  return (format === 'event-stream') || acceptable;
+};
+
+HttpContext.prototype.respondWithEventStream = function(stream) {
+  var client = new SSEClient(this.req, this.res);
+
+  client.initialize();
+
+  stream.on('data', function(chunk) {
+    client.send('data', JSON.stringify(chunk));
+  });
+
+  stream.on('error', function(err) {
+    var outErr = {message: err.message};
+    for (var key in err) {
+      outErr[key] = err[key];
+    }
+    client.send('error', JSON.stringify(outErr));
+  });
+
+  stream.on('end', function() {
+    client.send({event: 'end', data: 'null'});
+  });
+};
+
 /**
  * Finish the request and send the correct response.
  */
 
 HttpContext.prototype.done = function(cb) {
+  var ctx = this;
   var method = this.method;
-  var streamDesc = method.stream;
-  var methodReturnsStream = !!streamDesc;
+  var streamsDesc = method.streams;
+  var returnStreamDesc = streamsDesc && streamsDesc.returns;
+  var methodReturnsStream = !!returnStreamDesc;
   var res = this.res;
   var out = this.io && this.io.out;
   var err = this.error;
   var result = this.result;
 
   if (methodReturnsStream) {
-    if (streamDesc.json) {
+    if (returnStreamDesc.json) {
       debug('handling json stream');
-      res.setHeader('Content-Type',
-      streamDesc.contentType || 'application/json; boundary=NL');
-      res.setHeader('Transfer-Encoding', 'chunked');
 
-      var stream = result[streamDesc.arg];
+      var stream = result[returnStreamDesc.arg];
 
-      if (streamDesc.type === 'ReadableStream') {
+      if (returnStreamDesc.type === 'ReadableStream') {
+        if (ctx.shouldReturnEventStream()) {
+          debug('respondWithEventStream');
+          ctx.respondWithEventStream(stream);
+          return;
+        }
+
         debug('piping to mdm stream');
         stream.pipe(out);
         stream.on('error', function(err) {
@@ -474,7 +524,7 @@ HttpContext.prototype.done = function(cb) {
         });
         // TODO(ritch) support multi-part streams
       } else {
-        cb(new Error('unsupported stream type: ' + streamDesc.type));
+        cb(new Error('unsupported stream type: ' + returnStreamDesc.type));
       }
     } else {
       cb(new Error('Unsupported stream descriptor, only descriptors ' +

--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -22,6 +22,8 @@ var DEFAULT_SUPPORTED_TYPES = [
     '*/*'
   ];
 
+var MuxDemux = require('mux-demux');
+
 /**
  * Create a new `HttpContext` with the given `options`.
  *
@@ -48,6 +50,11 @@ function HttpContext(req, res, method, options) {
   }
 
   req.remotingContext = this;
+
+  // streaming support
+  if (methodReturnsStream) {
+    this.createStream();
+  }
 }
 
 /**
@@ -55,6 +62,22 @@ function HttpContext(req, res, method, options) {
  */
 
 inherits(HttpContext, EventEmitter);
+
+HttpContext.prototype.createStream = function() {
+  var streamDesc = this.method.stream;
+  var mdm = this.muxDemuxStream = new MuxDemux();
+  var io = this.io = {};
+  var res = this.res;
+
+  debug('create stream');
+
+  if (streamDesc.json && streamDesc.type === 'ReadableStream') {
+    this.io.out = mdm.createWriteStream();
+    // since the method returns a ReadableStream
+    // setup an output to pipe the ReadableStream to
+    mdm.pipe(res);
+  }
+};
 
 /**
  * Build args object from the http context's `req` and `res`.
@@ -417,11 +440,52 @@ function toXML(input) {
  * Finish the request and send the correct response.
  */
 
-HttpContext.prototype.done = function() {
+HttpContext.prototype.done = function(cb) {
+  var method = this.method;
+  var streamDesc = method.stream;
+  var methodReturnsStream = !!streamDesc;
+  var res = this.res;
+  var out = this.io && this.io.out;
+  var err = this.error;
+  var result = this.result;
+
+  if (methodReturnsStream) {
+    if (streamDesc.json) {
+      debug('handling json stream');
+      res.setHeader('Content-Type',
+      streamDesc.contentType || 'application/json; boundary=NL');
+      res.setHeader('Transfer-Encoding', 'chunked');
+
+      var stream = result[streamDesc.arg];
+
+      if (streamDesc.type === 'ReadableStream') {
+        debug('piping to mdm stream');
+        stream.pipe(out);
+        stream.on('error', function(err) {
+          var outErr = {message: err.message};
+          for (var key in err) {
+            outErr[key] = err[key];
+          }
+
+          // this is the reason we are using mux-demux
+          out.error(outErr);
+
+          out.end();
+        });
+        // TODO(ritch) support multi-part streams
+      } else {
+        cb(new Error('unsupported stream type: ' + streamDesc.type));
+      }
+    } else {
+      cb(new Error('Unsupported stream descriptor, only descriptors ' +
+        'with property "json:true" are supported'));
+    }
+    return;
+  }
+
   // send the result back as
   // the requested content type
   var data = this.result;
-  var res = this.res;
   var accepts = this.req.accepts(this.supportedTypes);
   var defaultStatus = this.method.http.status;
 
@@ -479,4 +543,6 @@ HttpContext.prototype.done = function() {
     }
     res.end();
   }
+
+  cb();
 };

--- a/lib/http-invocation.js
+++ b/lib/http-invocation.js
@@ -19,6 +19,8 @@ var Dynamic = require('./dynamic');
 var SUPPORTED_TYPES = ['json', 'application/javascript', 'text/javascript'];
 var qs = require('qs');
 var urlUtil = require('url');
+var ReadableStream = require('stream').Readable;
+var MuxDemux = require('mux-demux');
 
 /*!
  * JSON Types
@@ -158,7 +160,7 @@ HttpInvocation.prototype._processArg = function(req, verb, query, accept) {
 HttpInvocation.prototype.createRequest = function() {
   var method = this.method;
   var verb = method.getHttpMethod();
-  var req = this.req = {json: true, method: verb || 'GET'};
+  var req = this.req = {method: verb || 'GET'};
   var accepts = method.accepts;
   var ctorAccepts = null;
   var query;
@@ -167,6 +169,9 @@ HttpInvocation.prototype.createRequest = function() {
 
   // initial url is the format
   req.url = this.base + method.getFullPath();
+
+  // the body is json
+  req.json = true;
 
   // add auth if it is set
   if (auth) {
@@ -223,14 +228,37 @@ HttpInvocation.prototype.invoke = function(callback) {
   if (!this.req) {
     this.createRequest();
   }
-  request(this.req, function(err, res, body) {
-    if (err instanceof SyntaxError) {
-      if (res.status === 204) err = null;
+  var method = this.method;
+  var streamDesc = method.sharedMethod.stream;
+  var methodReturnsStream = !!streamDesc;
+  // var streamResult;
+
+  if (methodReturnsStream) {
+    if (streamDesc.type === 'ReadableStream' && streamDesc.json) {
+      var mdm = new MuxDemux();
+      mdm.on('connection', function(stream) {
+        callback(null, stream);
+      });
+
+      request(this.req).pipe(mdm);
+
+      // streamResult = request(this.req).pipe(JSONStream.parse());
+
+    } else {
+      callback(new Error('unsupported stream type'));
     }
-    if (err) return callback(err);
-    self.res = res;
-    self.transformResponse(res, body, callback);
-  });
+
+    return;
+  } else {
+    request(this.req, function(err, res, body) {
+      if (err instanceof SyntaxError) {
+        if (res.status === 204) err = null;
+      }
+      if (err) return callback(err);
+      self.res = res;
+      self.transformResponse(res, body, callback);
+    });
+  }
 };
 
 /*

--- a/lib/http-invocation.js
+++ b/lib/http-invocation.js
@@ -229,36 +229,32 @@ HttpInvocation.prototype.invoke = function(callback) {
     this.createRequest();
   }
   var method = this.method;
-  var streamDesc = method.sharedMethod.stream;
-  var methodReturnsStream = !!streamDesc;
-  // var streamResult;
+  var returnStreamDesc = method.sharedMethod.streams && method.sharedMethod.streams.returns;
+  var methodReturnsStream = !!returnStreamDesc;
 
   if (methodReturnsStream) {
-    if (streamDesc.type === 'ReadableStream' && streamDesc.json) {
+    if (returnStreamDesc.type === 'ReadableStream' && returnStreamDesc.json) {
       var mdm = new MuxDemux();
       mdm.on('connection', function(stream) {
         callback(null, stream);
       });
 
       request(this.req).pipe(mdm);
-
-      // streamResult = request(this.req).pipe(JSONStream.parse());
-
     } else {
       callback(new Error('unsupported stream type'));
     }
 
     return;
-  } else {
-    request(this.req, function(err, res, body) {
-      if (err instanceof SyntaxError) {
-        if (res.status === 204) err = null;
-      }
-      if (err) return callback(err);
-      self.res = res;
-      self.transformResponse(res, body, callback);
-    });
   }
+
+  request(this.req, function(err, res, body) {
+    if (err instanceof SyntaxError) {
+      if (res.status === 204) err = null;
+    }
+    if (err) return callback(err);
+    self.res = res;
+    self.transformResponse(res, body, callback);
+  });
 };
 
 /*

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -128,7 +128,6 @@ RestAdapter.prototype.invoke = function(method, ctorArgs, args, callback) {
       ctx.res = invocation.getResponse();
       remotes.execHooks('after', restMethod, scope, ctx, function(err) {
         if (err) { return callback(err); }
-
         callback.apply(invocation, args);
       });
     });
@@ -451,8 +450,11 @@ RestAdapter.prototype._invokeMethod = function(ctx, method, next) {
     steps,
     function(err) {
       if (err) return next(err);
-      ctx.done();
-      // Do not call next middleware, the request is handled
+      ctx.done(function(err) {
+        if (err) return next(err);
+        // otherwise do not call next middleware
+        // the request is handled
+      });
     }
   );
 };

--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -85,7 +85,6 @@ function SharedMethod(fn, name, sc, options) {
   this.documented = (options.documented || fn.documented) !== false;
   this.http = options.http || fn.http || {};
   this.rest = options.rest || fn.rest || {};
-  this.authorization = options.authorization;
   this.shared = options.shared;
   if (this.shared === undefined) {
     this.shared = true;
@@ -117,7 +116,7 @@ function SharedMethod(fn, name, sc, options) {
   var streamTypes = ['ReadableStream', 'WriteableStream', 'DuplexStream'];
 
   if (firstReturns && firstReturns.type && streamTypes.indexOf(firstReturns.type) > -1) {
-    this.stream = firstReturns;
+    this.streams = {returns: firstReturns};
   }
 
   if (this.errors && !Array.isArray(this.errors)) {

--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -85,6 +85,7 @@ function SharedMethod(fn, name, sc, options) {
   this.documented = (options.documented || fn.documented) !== false;
   this.http = options.http || fn.http || {};
   this.rest = options.rest || fn.rest || {};
+  this.authorization = options.authorization;
   this.shared = options.shared;
   if (this.shared === undefined) {
     this.shared = true;
@@ -111,6 +112,13 @@ function SharedMethod(fn, name, sc, options) {
     this.returns = [this.returns];
   }
   this.returns.forEach(normalizeArgumentDescriptor);
+
+  var firstReturns = this.returns[0];
+  var streamTypes = ['ReadableStream', 'WriteableStream', 'DuplexStream'];
+
+  if (firstReturns && firstReturns.type && streamTypes.indexOf(firstReturns.type) > -1) {
+    this.stream = firstReturns;
+  }
 
   if (this.errors && !Array.isArray(this.errors)) {
     this.errors = [this.errors];

--- a/package.json
+++ b/package.json
@@ -1,3 +1,4 @@
+
 {
   "name": "strong-remoting",
   "description": "StrongLoop Remoting Module",
@@ -13,24 +14,28 @@
     "test": "mocha"
   },
   "dependencies": {
-    "express": "4.x",
-    "body-parser": "^1.12.4",
-    "debug": "^2.2.0",
-    "eventemitter2": "^0.4.14",
-    "cors": "^2.6.0",
-    "jayson": "^1.2.0",
-    "js2xmlparser": "^0.1.9",
     "async": "^0.9.0",
+    "body-parser": "^1.7.0",
+    "cors": "^2.5.2",
+    "debug": "^2.0.0",
+    "eventemitter2": "^0.4.14",
+    "express": "4.x",
+    "inflection": "^1.4.2",
+    "jayson": "^1.1.1",
+    "js2xmlparser": "^0.1.3",
+    "mux-demux": "^3.7.9",
+    "qs": "^2.2.3",
+    "request": "^2.42.0",
+    "sse": "0.0.6",
     "traverse": "^0.6.6",
-    "request": "^2.55.0",
-    "qs": "^2.4.2",
-    "inflection": "^1.7.1",
-    "xml2js": "^0.4.8"
+    "xml2js": "^0.4.4"
   },
   "devDependencies": {
     "bluebird": "^2.9.25",
     "browserify": "~10.2.0",
-    "chai": "^2.3.0",
+    "chai": "^1.10.0",
+    "event-stream": "^3.3.1",
+    "eventsource": "^0.1.6",
     "grunt": "~0.4.5",
     "grunt-browserify": "~3.8.0",
     "grunt-cli": "^0.1.13",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "strong-remoting",
   "description": "StrongLoop Remoting Module",
@@ -15,25 +14,25 @@
   },
   "dependencies": {
     "async": "^0.9.0",
-    "body-parser": "^1.7.0",
-    "cors": "^2.5.2",
-    "debug": "^2.0.0",
+    "body-parser": "^1.12.4",
+    "cors": "^2.6.0",
+    "debug": "^2.2.0",
     "eventemitter2": "^0.4.14",
     "express": "4.x",
-    "inflection": "^1.4.2",
-    "jayson": "^1.1.1",
-    "js2xmlparser": "^0.1.3",
+    "inflection": "^1.7.1",
+    "jayson": "^1.2.0",
+    "js2xmlparser": "^0.1.9",
     "mux-demux": "^3.7.9",
-    "qs": "^2.2.3",
-    "request": "^2.42.0",
+    "qs": "^2.4.2",
+    "request": "^2.55.0",
     "sse": "0.0.6",
     "traverse": "^0.6.6",
-    "xml2js": "^0.4.4"
+    "xml2js": "^0.4.8"
   },
   "devDependencies": {
     "bluebird": "^2.9.25",
     "browserify": "~10.2.0",
-    "chai": "^1.10.0",
+    "chai": "^2.3.0",
     "event-stream": "^3.3.1",
     "eventsource": "^0.1.6",
     "grunt": "~0.4.5",

--- a/test/streams.js
+++ b/test/streams.js
@@ -1,8 +1,11 @@
 var assert = require('assert');
 var RemoteObjects = require('../');
+var expect = require('chai').expect;
+var SharedClass = require('../lib/shared-class');
 var express = require('express');
 var request = require('supertest');
 var fs = require('fs');
+var es = require('event-stream');
 
 describe('strong-remoting', function() {
   var app;
@@ -46,5 +49,89 @@ describe('strong-remoting', function() {
 
     json('get', '/fs/createReadStream?path=' + __dirname + '/data/foo.json&encoding=utf8')
       .expect({bar: 'baz'}, done);
+  });
+});
+
+describe('a function returning a ReadableStream', function() {
+  var Readable = require('stream').Readable;
+  var remotes = RemoteObjects.create();
+  var streamClass;
+  var server;
+
+  before(function(done) {
+    var test = this;
+    // NOTE: Date object will not be coerced back into a Date
+    var data = test.data = [{foo: 'bar'}, 'bat', false, 0, null];
+    var app = express();
+    server = app.listen(0, '127.0.0.1', done);
+    function StreamClass() {
+
+    }
+
+    StreamClass.createStream = function createStream(cb) {
+      cb(null, es.readArray(test.data));
+    };
+
+    StreamClass.createStreamWithError = function createStreamWithError(cb) {
+      var rs = new Readable({objectMode: true});
+      rs._read = function() {
+        rs.emit('error', new Error('test error'));
+      };
+      cb(null, rs);
+    };
+
+    streamClass = new SharedClass('StreamClass', StreamClass);
+
+    streamClass.defineMethod('createStream', {
+      isStatic: true,
+      fn: StreamClass.createStream,
+      returns: [{
+        arg: 'stream',
+        type: 'ReadableStream',
+        json: true
+      }]
+    });
+
+    streamClass.defineMethod('createStreamWithError', {
+      isStatic: true,
+      fn: StreamClass.createStreamWithError,
+      returns: [{
+        arg: 'stream',
+        type: 'ReadableStream',
+        json: true
+      }]
+    });
+
+    remotes.addClass(streamClass);
+    app.use(remotes.handler('rest'));
+  });
+
+  before(function() {
+    remotes.connect('http://127.0.0.1:' + server.address().port, 'rest');
+  });
+
+  it('should return a ReadableStream', function(done) {
+    var testData = this.data;
+    remotes.invoke('StreamClass.createStream', [], function(err, stream) {
+      assert(stream.readable, 'must be a ReadableStream');
+      var out = es.writeArray(function (err, result) {
+        if(err) return done(err);
+        expect(testData).to.eql(result);
+        done();
+      });
+
+      stream.pipe(out);
+    });
+  });
+
+  it('should include errors', function(done) {
+    remotes.invoke('StreamClass.createStreamWithError', [], function(err, stream) {
+      stream.on('error', function(err) {
+        expect(err).instanceof(Error);
+        expect(err.message).to.equal('test error');
+      });
+
+      stream.on('end', done);
+    });
   });
 });

--- a/test/streams.js
+++ b/test/streams.js
@@ -6,6 +6,7 @@ var express = require('express');
 var request = require('supertest');
 var fs = require('fs');
 var es = require('event-stream');
+var EventSource = require('eventsource');
 
 describe('strong-remoting', function() {
   var app;
@@ -57,12 +58,13 @@ describe('a function returning a ReadableStream', function() {
   var remotes = RemoteObjects.create();
   var streamClass;
   var server;
+  var app;
 
   before(function(done) {
     var test = this;
-    // NOTE: Date object will not be coerced back into a Date
+    // NOTE: Date is intentionally excluded as it is not supported yet
     var data = test.data = [{foo: 'bar'}, 'bat', false, 0, null];
-    var app = express();
+    app = express();
     server = app.listen(0, '127.0.0.1', done);
     function StreamClass() {
 
@@ -74,19 +76,24 @@ describe('a function returning a ReadableStream', function() {
 
     StreamClass.createStreamWithError = function createStreamWithError(cb) {
       var rs = new Readable({objectMode: true});
+
       rs._read = function() {
-        rs.emit('error', new Error('test error'));
+        // required method
       };
+
+      process.nextTick(function() {
+        rs.emit('error', new Error('test error'));
+      });
       cb(null, rs);
     };
 
     streamClass = new SharedClass('StreamClass', StreamClass);
 
-    streamClass.defineMethod('createStream', {
+    this.createStreamMethod = streamClass.defineMethod('createStream', {
       isStatic: true,
       fn: StreamClass.createStream,
       returns: [{
-        arg: 'stream',
+        arg: 'result',
         type: 'ReadableStream',
         json: true
       }]
@@ -96,7 +103,7 @@ describe('a function returning a ReadableStream', function() {
       isStatic: true,
       fn: StreamClass.createStreamWithError,
       returns: [{
-        arg: 'stream',
+        arg: 'result',
         type: 'ReadableStream',
         json: true
       }]
@@ -114,8 +121,8 @@ describe('a function returning a ReadableStream', function() {
     var testData = this.data;
     remotes.invoke('StreamClass.createStream', [], function(err, stream) {
       assert(stream.readable, 'must be a ReadableStream');
-      var out = es.writeArray(function (err, result) {
-        if(err) return done(err);
+      var out = es.writeArray(function(err, result) {
+        if (err) return done(err);
         expect(testData).to.eql(result);
         done();
       });
@@ -132,6 +139,51 @@ describe('a function returning a ReadableStream', function() {
       });
 
       stream.on('end', done);
+    });
+  });
+
+  describe('an http client requesting a stream as an event source', function() {
+    before(function(done) {
+      var server = this.server = app.listen(done);
+      this.port = server.address().port;
+    });
+    before(function() {
+      var test = this;
+      this.url = 'http://localhost:' + this.port;
+    });
+
+    it('should respond with an event stream', function(done) {
+      var es = new EventSource(this.url + '/StreamClass/createStream');
+      var testData = this.data;
+      var result = [];
+
+      es.on('data', function(e) {
+        result.push(JSON.parse(e.data));
+      });
+
+      es.on('end', function() {
+        expect(testData).to.eql(result);
+        done();
+      });
+    });
+
+    it('should respond with an event stream with errors', function(done) {
+      var es = new EventSource(this.url + '/StreamClass/createStreamWithError');
+
+      es.on('error', function(e) {
+        var err;
+        if (e && e.data) {
+          err = JSON.parse(e.data);
+        } else {
+          return done(new Error('no error data!'));
+        }
+        expect(err.message).to.equal('test error');
+        done();
+      });
+    });
+
+    after(function() {
+      this.server.close();
     });
   });
 });


### PR DESCRIPTION
This PR adds support for returning object mode `ReadableStream`s.

connect to strongloop/strong-remoting#214

Using HTTP `ReadableStream`s are piped to the `res` using https://github.com/dominictarr/mux-demux. This allows for `stream.on('error')`s to be sent using the multiplexed NL separated JSON protocol.

I would still like to add the same exact capability using multipart responses.

/to @bajtos 
/cc @raymondfeng @kraman @rmg (noticed you had used mux-demux)