### PR TITLE
Rest Test: fixed express deprecation warning

### DIFF
--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -165,7 +165,7 @@ describe('strong-remoting-rest', function() {
     it('should turn off url-not-found handler', function(done) {
       objects.options.rest = { handleUnknownPaths: false };
       app.use(function(req, res, next) {
-        res.send(404, 'custom-not-found');
+        res.status(404).send('custom-not-found');
       });
 
       request(app).get('/thisUrlDoesNotExists/someMethod')


### PR DESCRIPTION
Fixes 'express deprecated res.send(status, body): Use res.status(status).send(body) instead'