### PR TITLE
HttpContext: do not lowercase type when resolving dynamic converter

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -75,8 +75,8 @@ HttpContext.prototype.buildArgs = function(method) {
     // Support array types, such as ['string']
     var isArrayType = Array.isArray(o.type);
     var otype = isArrayType ? o.type[0] : o.type;
-    otype = (typeof otype === 'string') && otype.toLowerCase();
-    var isAny = !otype || otype === 'any';
+    otype = (typeof otype === 'string') && otype;
+    var isAny = !otype || otype.toLowerCase() === 'any';
 
     // This is an http method keyword, which requires special parsing.
     if (httpFormat) {

--- a/test/http-context.test.js
+++ b/test/http-context.test.js
@@ -1,6 +1,7 @@
 var request = require('supertest');
 var HttpContext = require('../lib/http-context');
 var SharedMethod = require('../lib/shared-method');
+var Dynamic = require('../lib/dynamic');
 var expect = require('chai').expect;
 
 describe('HttpContext', function() {
@@ -72,6 +73,24 @@ describe('HttpContext', function() {
         type: 'any',
         input: '000123',
         expectedValue: '000123'
+      }));
+    });
+
+    describe('arguments with custom type', function() {
+      Dynamic.define('CustomType', function(val) {
+        return JSON.parse(val);
+      });
+
+      it('should coerce dynamic type with string prop into object', givenMethodExpectArg({
+        type: 'CustomType',
+        input: JSON.stringify({ stringProp: 'string' }),
+        expectedValue: { stringProp: 'string' }
+      }));
+
+      it('should coerce dynamic type with int prop into object', givenMethodExpectArg({
+        type: 'CustomType',
+        input: JSON.stringify({ intProp: 1 }),
+        expectedValue: { intProp: 1 }
       }));
     });
   });


### PR DESCRIPTION
Fixes strongloop/loopback#906