### PR TITLE
fix long lines in docs that were failing jshint

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -15,28 +15,34 @@ var assert = require('assert');
  *
  * @property {String} name The method name.
  * @property {String[]} aliases An array of method aliases.
- * @property {Boolean} isStatic Whether the method is static; from `options.isStatic`.  Default is `true`.
+ * @property {Boolean} isStatic Whether the method is static; from `options.isStatic`.
+ * Default is `true`.
  * @property {Array|Object} accepts See `options.accepts`.
  * @property {Array|Object} returns See `options.returns`.
  * @property {Array|Object} errors See `options.errors`.
  * @property {String} description Text description of the method.
- * @property {String} notes Additional notes, used by API documentation generators like Swagger.
+ * @property {String} notes Additional notes, used by API documentation generators like
+ * Swagger.
  * @property {String} http
  * @property {String} rest
  * @property {String} shared
- * @property {Boolean} [documented] Default: true. Set to `false` to exclude the method from Swagger metadata.
+ * @property {Boolean} [documented] Default: true. Set to `false` to exclude the method
+ * from Swagger metadata.
  *
  * @param {Function} fn The `Function` to be invoked when the method is invoked.
  * @param {String} name The name of the `SharedMethod`.
  * @param {SharedClass} sharedClass The `SharedClass` to which the method will be attached.
  *
  * @options {Object} options See below.
- * @property {Array|Object} [accepts] Defines either a single argument as an object or an ordered set of arguments as an array.
+ * @property {Array|Object} [accepts] Defines either a single argument as an object or an
+ * ordered set of arguments as an array.
  * @property {String} [accepts.arg] The name of the argument.
- * @property {String} [accepts.description] Text description of the argument, used by API documentation generators like Swagger.
- * @property {String} [accepts.http] HTTP mapping for the argument.
- * See [HTTP mapping of input arguments](http://docs.strongloop.com/display/LB/Remote+methods#Remotemethods-HTTPmappingofinputarguments).
- * @property {String} [accepts.http.source] The HTTP source for the  argument. May be one of the following:
+ * @property {String} [accepts.description] Text description of the argument, used by API
+ * documentation generators like Swagger.
+ * @property {String} [accepts.http] HTTP mapping for the argument. See argument mapping in
+ * [the docs](http://docs.strongloop.com/x/-Yw6#Remotemethods-HTTPmappingofinputarguments).
+ * @property {String} [accepts.http.source] The HTTP source for the  argument. May be one
+ * of the following:
  *
  * - `req` - the Express `Request` object.
  * - `res` - the Express `Response` object.
@@ -47,18 +53,24 @@ var assert = require('assert');
  * - `header` - `req.headers[argumentName]`.
  * - `context` - the current `HttpContext`.
  * @property {Object} [accepts.rest] The REST mapping / settings for the argument.
- * @property {String} [accepts.type] Argument datatype; must be a [Loopback type](http://docs.strongloop.com/display/LB/LoopBack+types).
+ * @property {String} [accepts.type] Argument datatype; must be a
+ * [Loopback type](http://docs.strongloop.com/display/LB/LoopBack+types).
  * @property {Array} [aliases] A list of aliases for the method.
  * @property {Array|Object} [errors] Object or `Array` containing error definitions.
  * @property {Array} [http] HTTP-only options.
  * @property {Number} [http.errorStatus] Default error status code.
- * @property {String} [http.path] HTTP path (relative to the model) at which the method is exposed.
- * @property {Number} [http.status] Default status code when the callback is called _without_ an error.
- * @property {String} [http.verb] HTTP method (verb) at which the method is available. One of:
- * get, post (default), put, del, or all
- * @property {Boolean} [isStatic] Whether the method is a static method or a prototype method.
- * @property {Array|Object} [returns] Specifies the remote method's callback arguments; either a single argument as an object or an ordered set of arguments as an array.
- * The `err` argument is assumed; do not specify.  NOTE: Can have the same properties as `accepts`, except for `http.target`.
+ * @property {String} [http.path] HTTP path (relative to the model) at which the method is
+ * exposed.
+ * @property {Number} [http.status] Default status code when the callback is called
+ * _without_ an error.
+ * @property {String} [http.verb] HTTP method (verb) at which the method is available.
+ * One of: get, post (default), put, del, or all
+ * @property {Boolean} [isStatic] Whether the method is a static method or a prototype
+ * method.
+ * @property {Array|Object} [returns] Specifies the remote method's callback arguments;
+ * either a single argument as an object or an ordered set of arguments as an array.
+ * The `err` argument is assumed; do not specify.  NOTE: Can have the same properties as
+ * `accepts`, except for `http.target`.
  * @property {Boolean} [shared] Whether the method is shared.  Default is `true`.
  * @property {Number} [status] The default status code.
  * @end


### PR DESCRIPTION
Introduced in 4d96596

@crandmck I tried to only wrap the long lines, but I had to take some liberties with the one particularly long URL (including replacing it with a Confluence generated short URL), so you are probably the best to review.

/cc @ritch @raymondfeng because linting is part of this module's tests, doc changes can break the build. For that reason I recommend doc changes go through the PR process so that they can at least be linted before merging.