### PR TITLE
Explicitly set req.protocol

### DIFF
--- a/lib/http-invocation.js
+++ b/lib/http-invocation.js
@@ -170,6 +170,10 @@ HttpInvocation.prototype.createRequest = function() {
   // initial url is the format
   req.url = this.base + method.getFullPath();
 
+  var parsedUrl = urlUtil.parse(req.url);
+
+  req.protocol = parsedUrl.protocol;
+
   // the body is json
   req.json = true;
 


### PR DESCRIPTION
/to @raymondfeng 

This fixes https://github.com/strongloop/strong-remoting/issues/229

Without setting the `req.protocol` the browserify implementation of `http` incorrectly falls back to the `window.location.protocol` (which is `file:`).