### PR TITLE
verify the accepts size <= 5000

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -472,7 +472,8 @@ SharedMethod.convertArg = function(accept, raw) {
     )) {
     return raw;
   }
-  if (raw === null || typeof raw !== 'object') {
+  if (raw === null || typeof raw !== 'object' ||
+     util.inspect(raw).length > 5000) {
     return raw;
   }
   var data = traverse(raw).forEach(function(x) {

--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -472,10 +472,16 @@ SharedMethod.convertArg = function(accept, raw) {
     )) {
     return raw;
   }
-  if (raw === null || typeof raw !== 'object' ||
-     util.inspect(raw).length > 5000) {
+  if (raw === null || typeof raw !== 'object') {
     return raw;
   }
+  if (typeof raw === 'object' &&
+      raw.constructor !== Object &&
+      raw.constructor !== Array) {
+    // raw is not plain
+    return raw;
+  }
+
   var data = traverse(raw).forEach(function(x) {
     if (x === null || typeof x !== 'object') {
       return x;


### PR DESCRIPTION
We should be careful with the `raw` size to call traverse, here because this use case is edge one, so I think the inspect call might have too much consumes on normal remote routing.

R= @ritch 
/cc @raymondfeng 