### PR TITLE
Remove deprecation warning for res.send()

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -584,13 +584,12 @@ HttpContext.prototype.done = function(cb) {
             var xml = toXML(data);
             res.send(xml);
           } catch (e) {
-            res.send(500, e + '\n' + data);
+            res.status(500).send(e + '\n' + data);
           }
         }
         break;
       default:
-        // not acceptable
-        res.send(406);
+        res.status(406).send('Not Acceptable');
         break;
     }
   } else {


### PR DESCRIPTION
Small patch that removes the following warnings:

```
express deprecated res.send(status, body): Use res.status(status).send(body) instead node_modules/loopback/node_modules/strong-remoting/lib/http-context.js:587:17
```
```
express deprecated res.send(status): Use res.sendStatus(status) instead node_modules/loopback/node_modules/strong-remoting/lib/http-context.js:593:13
```