### PR TITLE
Use strict jayson version to prevent regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "eventemitter2": "^0.4.14",
     "express": "4.x",
     "inflection": "^1.7.1",
-    "jayson": "~1.2.0",
+    "jayson": "1.2.0",
     "js2xmlparser": "^0.1.9",
     "mux-demux": "^3.7.9",
     "qs": "^2.4.2",


### PR DESCRIPTION
The recently released version jayson@1.2.1 introduced a breaking change
in https://github.com/tedeh/jayson/commit/dc0a13dc4 which is causing
our json-rpc adapter to fail, because we are passing a zero-argument
wrapper function to jayson.

This commit is changing the jayson dependency to strict version 1.2.0, which is the latest
version working for us.

/to @ritch @raymondfeng please review