### PR TITLE
Generate wrapper function with same params as the original one

### DIFF
--- a/lib/jsonrpc-adapter.js
+++ b/lib/jsonrpc-adapter.js
@@ -97,6 +97,20 @@ JsonRpcAdapter.errorHandler = function() {
   };
 };
 
+// A mock wrapper function to help code generation via mockWrapper.toString()
+function mockWrapper(method) {
+  return function(__args__) {
+    var args = Array.prototype.slice.call(arguments);
+    if (method.isStatic) {
+      method.getFunction().apply(method.ctor, args);
+    } else {
+      method.sharedCtor.invoke(method, function(err, instance) {
+        method.getFunction().apply(instance, args);
+      });
+    }
+  };
+}
+
 JsonRpcAdapter.prototype.createHandler = function() {
 
   var root = express.Router();
@@ -148,33 +162,37 @@ JsonRpcAdapter.prototype.createHandler = function() {
 
     methods.forEach(function(method) {
       // Wrap the method so that it will keep its own receiver - the shared class
-      var fn = function() {
-        var args = arguments;
-        if (method.isStatic) {
-          method.getFunction().apply(method.ctor, args);
-        } else {
-          method.sharedCtor.invoke(method, function(err, instance) {
-            method.getFunction().apply(instance, args);
-          });
-        }
-      };
-
-      /*
-      I had to this because jayson uses fn.toString to map the parameters,
-      and since you wrap the method, the jsonrpc server cannot read them.
-      I solved this overwriting the toString method on the wrapped function,
-      creating this fake string that has the paramenters names in it.
-      */
+      var argsNames = '';
       if (method.accepts) {
-        var argsNames = method.accepts.map(function(item) {
+        argsNames = method.accepts.map(function(item) {
           return item.arg;
         });
-
-        fn.toString = function() {
-          return 'function (' + argsNames.concat('callback').join(',') + '){}';
-        };
+        argsNames = argsNames.join(',');
+      } else {
+        var m = method.getFunction();
+        if (m.length > 1) {
+          // The method has more args than cb
+          // Build dummy param names
+          var names = [];
+          for (var i = 0; i < m.length - 1; i++) {
+            names.push('param' + i);
+          }
+          argsNames = names.join(',');
+        }
       }
+      argsNames = argsNames ? argsNames + ',cb' : 'cb';
 
+      // Generate the function based on the wrapper
+      // We need to remove the header/footer to get the function body
+      var funcBody = mockWrapper.toString().
+        replace('function mockWrapper(method) {', '').
+        replace('__args__', argsNames).
+        replace(/}$/, '');
+      /*jslint evil: true */
+      var fn = new Function('method', funcBody)(method);
+      if (debug.enabled) {
+        debug('Generated function: %s', fn.toString());
+      }
       server.method(method.name, fn);
     });
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "eventemitter2": "^0.4.14",
     "express": "4.x",
     "inflection": "^1.7.1",
-    "jayson": "1.2.0",
+    "jayson": "^1.2.0",
     "js2xmlparser": "^0.1.9",
     "mux-demux": "^3.7.9",
     "qs": "^2.4.2",

--- a/test/jsonrpc.test.js
+++ b/test/jsonrpc.test.js
@@ -37,6 +37,9 @@ describe('strong-remoting-jsonrpc', function() {
         function greet(msg, fn) {
           fn(null, msg);
         }
+        greet.accepts = [
+          {'arg':'msg', 'type':'string'}
+        ];
 
         // Create a shared method directly on the function object
         remotes.user = {


### PR DESCRIPTION
/to @ritch @bajtos 

See https://github.com/tedeh/jayson/commit/dc0a13dc4e50880478a446eb682a75f36ef27e3d