### PR TITLE
stringify mockWrapper so we can generate coverage

### DIFF
--- a/lib/jsonrpc-adapter.js
+++ b/lib/jsonrpc-adapter.js
@@ -97,20 +97,26 @@ JsonRpcAdapter.errorHandler = function() {
   };
 };
 
-// A mock wrapper function to help code generation via mockWrapper.toString()
-function mockWrapper(method) {
-  return function(__args__) {
-    var args = Array.prototype.slice.call(arguments);
-    if (method.isStatic) {
-      method.getFunction().apply(method.ctor, args);
-    } else {
-      method.sharedCtor.invoke(method, function(err, instance) {
-        method.getFunction().apply(instance, args);
-      });
-    }
-  };
-}
+// A mock wrapper function to help code generation.
+// Note that we can't make it a real function and use .toString() on it because
+// that causes a whole world of trouble when we run strong-remoting's unit tests
+// with code coverage.
+var mockWrapper = [
+'function mockWrapper(method) {',
+'  return function(__args__) {',
+'    var args = Array.prototype.slice.call(arguments);',
+'    if (method.isStatic) {',
+'      method.getFunction().apply(method.ctor, args);',
+'    } else {',
+'      method.sharedCtor.invoke(method, function(err, instance) {',
+'        method.getFunction().apply(instance, args);',
+'      });',
+'    }',
+'  };',
+'}',
+].join('\n');
 
+/* istanbul ignore next */
 JsonRpcAdapter.prototype.createHandler = function() {
 
   var root = express.Router();


### PR DESCRIPTION
This has to be done because when we run the tests with coverage the
function body gets mangled by instrumentation and the string
replacements fail horribly. The end result is the generated function
ends up not even being valid JavaScript and the tests then fail for
obvious reasons.