### PR TITLE
Add options to `sharedClass.methods()` for including all methods

### DIFF
--- a/lib/shared-class.js
+++ b/lib/shared-class.js
@@ -83,14 +83,18 @@ SharedClass.normalizeHttpPath = function(path) {
 /**
  * Get all shared methods belonging to this shared class.
  *
+ * @param options {Object}
+ * @param options.includeDisabled {Boolean} include all methods, even disabled.
  * @returns {SharedMethod[]} An array of shared methods
  */
 
-SharedClass.prototype.methods = function() {
+SharedClass.prototype.methods = function(options) {
   var ctor = this.ctor;
   var methods = [];
   var sc = this;
   var functionIndex = [];
+
+  options = options || {};
 
   // static methods
   eachRemoteFunctionInObject(ctor, function(fn, name) {
@@ -122,6 +126,10 @@ SharedClass.prototype.methods = function() {
   });
 
   methods = methods.concat(this._methods);
+
+  if (options.includeDisabled === true) {
+    return methods;
+  }
 
   return methods.filter(sc.isMethodEnabled.bind(sc));
 };

--- a/test/shared-class.test.js
+++ b/test/shared-class.test.js
@@ -50,6 +50,23 @@ describe('SharedClass', function() {
       expect(fns).to.contain(SomeClass.staticMethod);
       expect(fns).to.contain(SomeClass.prototype.instanceMethod);
     });
+    it('returns all methods when includeDisabled is true', function() {
+      var sc = new SharedClass('MySharedClass', MySharedClass);
+      function MySharedClass() {
+        // this page left intentionally blank
+      }
+
+      var inputNames = ['foo', 'bar'];
+
+      sc.defineMethod(inputNames[0], {shared: false});
+      sc.defineMethod(inputNames[1], {shared: true});
+
+      var outputNames = sc.methods({includeDisabled: true}).map(function(m) {
+        return m.name;
+      });
+
+      expect(outputNames).to.eql(inputNames);
+    });
     it('only discovers a function once with aliases', function() {
       function MyClass() {}
       var sc = new SharedClass('some', MyClass);


### PR DESCRIPTION
/to @superkhau 