### PR TITLE
Modify RestAdapter to allow disabling errorHandler

### DIFF
--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -303,15 +303,21 @@ RestAdapter.prototype.createHandler = function() {
     root.use(RestAdapter.urlNotFoundHandler());
   }
 
-  // Use our own error handler to make sure the error response has
-  // always the format expected by remoting clients.
-  root.use(RestAdapter.errorHandler(this.remotes.options.errorHandler));
+  if (this._shouldHandleErrors()) {
+    // Use our own error handler to make sure the error response has
+    // always the format expected by remoting clients.
+    root.use(RestAdapter.errorHandler(this.remotes.options.errorHandler));
+  }
 
   return root;
 };
 
 RestAdapter.prototype._shouldHandleUnknownPaths = function() {
   return !(this.options && this.options.handleUnknownPaths === false);
+};
+
+RestAdapter.prototype._shouldHandleErrors = function() {
+  return !(this.options && this.options.handleErrors === false);
 };
 
 RestAdapter.remoteMethodNotFoundHandler = function(className) {

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -188,6 +188,31 @@ describe('strong-remoting-rest', function() {
         .end(done);
     });
 
+    it('should by default use defined error handler', function(done) {
+      app.use(function(err, req, res, next) {
+        res.send('custom-error-handler-called');
+      });
+
+      request(app).get('/thisUrlDoesNotExists/someMethod')
+        .expect(404)
+        .expect(function(res) {
+          expect(res.text).not.to.equal('custom-error-handler-called');
+        })
+        .end(done);
+    });
+
+    it('should turn off error handler', function(done) {
+      objects.options.rest = { handleErrors: false };
+      app.use(function(err, req, res, next) {
+        res.send('custom-error-handler-called');
+      });
+
+      request(app).get('/thisUrlDoesNotExists/someMethod')
+        .expect(200)
+        .expect('custom-error-handler-called')
+        .end(done);
+    });
+
     it('should configure custom REST content types', function(done) {
       var supportedTypes = ['json', 'application/javascript', 'text/javascript'];
       objects.options.rest = { supportedTypes: supportedTypes };


### PR DESCRIPTION
options.handleErrors = false will allow the RestAdapter error handler
to be bypassed

See: https://github.com/strongloop/loopback/issues/445#issuecomment-147722977 for discussion

@bajtos does this look ok?