### PR TITLE
WIP : Add sharedClass access inside restClass

### DIFF
--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -535,6 +535,7 @@ function RestClass(sharedClass) {
 
   this.name = sharedClass.name;
   this.routes = getRoutes(sharedClass);
+  this.sharedClass = sharedClass;
 
   this.ctor = sharedClass.sharedCtor &&
     new RestMethod(this, sharedClass.sharedCtor);

--- a/test/rest-adapter.test.js
+++ b/test/rest-adapter.test.js
@@ -33,6 +33,13 @@ describe('RestAdapter', function() {
         .eql([{ path: '/test-class', verb: 'any' }]);
     });
 
+    it('fills `sharedClass`', function() {
+      remotes.exports.testClass = factory.createSharedClass();
+      var classes = getRestClasses();
+      expect(classes[0]).to.have.property('sharedClass');
+      expect(classes[0].sharedClass).to.be.an.instanceOf(SharedClass);
+    });
+
     it('fills `ctor`', function() {
       var testClass = remotes.exports.testClass = factory.createSharedClass();
       testClass.sharedCtor.http = { path: '/shared-ctor', verb: 'all' };


### PR DESCRIPTION
- Added sharedClass as an attribute of restClass
- Reason: Description of Model needed for loopback-angular-sdk
- https://github.com/strongloop/loopback-sdk-angular/issues/132

Signed-off-by: David Cheung <davidcheung@ca.ibm.com>