### PR TITLE
Enable default values for arguments

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -212,7 +212,12 @@ SharedMethod.prototype.invoke = function(scope, args, remotingOptions, ctx, cb) 
       var desc = accepts[i];
       var name = desc.name || desc.arg;
       var uarg = SharedMethod.convertArg(desc, args[name]);
-
+      
+      // Uses arg default value if argument is not provided.
+      if (uarg == undefined && desc.default != undefined) {
+        uarg = desc.default;
+      }
+      
       try {
         uarg = coerceAccepts(uarg, desc, name);
       } catch (e) {

--- a/test/shared-method.test.js
+++ b/test/shared-method.test.js
@@ -79,6 +79,30 @@ describe('SharedMethod', function() {
   });
 
   describe('sharedMethod.invoke', function() {
+    it('returns default value on custom remote method when parameter is not passed', function(done){
+      var defaultValue = 100;
+      var method = givenSharedMethod(
+        function(num, next) { 
+          return new Promise(function(resolve, reject) {
+            if(typeof num === 'number'){
+              return resolve({num: num});
+            }
+            return reject(new Error('Parameter is not a number'));
+          });
+        },
+        {
+          accepts: [{ arg: 'num', type: 'number', default:defaultValue }],
+          returns: {root:true, type:'object'}
+      });
+      
+      method.invoke('ctx', {}, function(err, result){
+        setImmediate(function(){
+          expect(result).to.exist;
+          expect(result.num).to.equal(defaultValue);
+          done();
+        });
+      });
+    });
     it('returns 400 when number argument is `NaN`', function(done) {
       var method = givenSharedMethod({
         accepts: [{ arg: 'num', type: 'number' }]


### PR DESCRIPTION
Loopback explorer utilises a default value property on arguments in order to pre-populate input fields. This default is also exposed in the swagger.json. This simply utilizes that default property when invoking the remote method if a value has not been defined in the request.