### PR TITLE
Don't coerce null to 'null' with string accepts in shared-method.

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -289,6 +289,7 @@ function coerceAccepts(uarg, desc) {
   var name = desc.name || desc.arg;
   var targetType = convertToBasicRemotingType(desc.type);
   var targetTypeIsArray = Array.isArray(targetType) && targetType.length === 1;
+  var argIsNullOrUndefined = uarg === null || uarg === undefined;
 
   // If coercing an array to an erray,
   // then coerce all members of the array too
@@ -309,7 +310,7 @@ function coerceAccepts(uarg, desc) {
   // TODO(bajtos) Move conversions to HttpContext (and friends)
   // SharedMethod should only check that argument values match argument types.
   var conversionNeeded = targetType !== 'any' &&
-    actualType !== 'undefined' &&
+    !argIsNullOrUndefined &&
     actualType !== targetType;
 
   if (conversionNeeded) {
@@ -326,7 +327,7 @@ function coerceAccepts(uarg, desc) {
   }
 
   var typeMismatch = targetType !== 'any' &&
-    actualType !== 'undefined' &&
+    !argIsNullOrUndefined &&
     targetType !== actualType &&
     // In JavaScript, an array is an object too (typeof [] === 'object').
     // However, SharedMethod.getType([]) returns 'array' instead of 'object'.
@@ -342,12 +343,11 @@ function coerceAccepts(uarg, desc) {
   }
 
   // Verify that a required argument has a value
-  // FIXME(bajtos) "null" should be treated as no value too
-  if (actualType === 'undefined') {
+  if (argIsNullOrUndefined) {
     if (desc.required) {
       throw new badArgumentError(name + ' is a required arg');
     } else {
-      return undefined;
+      return uarg; // returns null or undefined
     }
   }
 

--- a/test/shared-method.test.js
+++ b/test/shared-method.test.js
@@ -188,17 +188,38 @@ describe('SharedMethod', function() {
         });
       });
     });
-
-    function givenSharedMethod(fn, options) {
-      if (options === undefined && typeof fn === 'object') {
-        options = fn;
-        fn = function() {
-          arguments[arguments.length - 1]();
-        };
-      }
-
-      var mockSharedClass = { fn: fn };
-      return new SharedMethod(fn, 'fn', mockSharedClass, options);
-    }
   });
+
+  describe('accepts coercion', function() {
+
+    it('Doesn\'t coerce null to "null"', function(done) {
+      var method = givenSharedMethod(
+        function(str) {
+          expect(str).to.eql(null);
+          expect(typeof str).to.eql('object');
+          return Promise.resolve();
+        },
+        {
+          accepts: [{ arg: 'str', type: 'string' }]
+        }
+      );
+
+      method.invoke('ctx', { str: null }, function(err, result) {
+        expect(err && err.message).not.to.exist;
+        done();
+      });
+    });
+  });
+
+  function givenSharedMethod(fn, options) {
+    if (options === undefined && typeof fn === 'object') {
+      options = fn;
+      fn = function() {
+        arguments[arguments.length - 1]();
+      };
+    }
+
+    var mockSharedClass = { fn: fn };
+    return new SharedMethod(fn, 'fn', mockSharedClass, options);
+  }
 });


### PR DESCRIPTION
A method definition with a string argument would coerce `null` to `'null'`. 

connect to #263