### PR TITLE
Fix incorrect boolean logic on shared-method's `documented` flag.

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -96,7 +96,7 @@ function SharedMethod(fn, name, sc, options) {
   this.description = options.description || fn.description;
   this.accessType = options.accessType || fn.accessType;
   this.notes = options.notes || fn.notes;
-  this.documented = (options.documented || fn.documented) !== false;
+  this.documented = options.documented !== false && fn.documented !== false;
   this.http = options.http || fn.http || {};
   this.rest = options.rest || fn.rest || {};
   this.shared = options.shared;

--- a/test/shared-method.test.js
+++ b/test/shared-method.test.js
@@ -29,6 +29,14 @@ describe('SharedMethod', function() {
         { arg: 'data', type: ['any'] }
       ]);
     });
+
+    it('passes along `documented` flag correctly', function() {
+      var sharedMethod = new SharedMethod(STUB_METHOD, 'a-name', STUB_CLASS, {
+        documented: false
+      });
+
+      expect(sharedMethod.documented).to.eql(false);
+    });
   });
 
   describe('sharedMethod.isDelegateFor(suspect, [isStatic])', function() {


### PR DESCRIPTION
Boolean comparisons don't work like that - as written it's not possible to actually make the `documented` flag stick.