### PR TITLE
update check for turning off sloppy coercion when body request is application/json

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -171,7 +171,8 @@ HttpContext.prototype.buildArgs = function(method) {
     // If this is from the body and we were doing a JSON POST, turn off sloppy coercion.
     // This is because JSON, unlike other methods, properly retains types like Numbers,
     // Booleans, and null/undefined.
-    if (ctx.req.body && ctx.req.get('content-type') === 'application/json' &&
+    if (ctx.req.body && ctx.req.get('content-type') && 
+        ctx.req.get('content-type').substr(0, 16) === 'application/json' &&
         (ctx.req.body === val || ctx.req.body[name] === val)) {
       doSloppyCoerce = false;
     }

--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -171,7 +171,7 @@ HttpContext.prototype.buildArgs = function(method) {
     // If this is from the body and we were doing a JSON POST, turn off sloppy coercion.
     // This is because JSON, unlike other methods, properly retains types like Numbers,
     // Booleans, and null/undefined.
-    if (ctx.req.body && ctx.req.get('content-type') && 
+    if (ctx.req.body && ctx.req.get('content-type') &&
         ctx.req.get('content-type').substr(0, 16) === 'application/json' &&
         (ctx.req.body === val || ctx.req.body[name] === val)) {
       doSloppyCoerce = false;


### PR DESCRIPTION
Check and fix if the content-type header is an application/json request type.
Allow now the charset definition in the content-type (i.e 'application/json;charset=UTF-8').

Connect to #267 