### PR TITLE
Retain accepted content-type with no-content

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -491,6 +491,74 @@ HttpContext.prototype.respondWithEventStream = function(stream) {
 };
 
 /**
+ * Utility functions to send response body
+ */
+function sendBodyJson(res, data) {
+  res.json(data);
+}
+
+function sendBodyJsonp(res, data) {
+  res.jsonp(data);
+}
+
+function sendBodyXml(res, data) {
+  if (data === null) {
+    res.header('Content-Length', '7');
+    res.send('<null/>');
+  } else if (data) {
+    try {
+      var xml = toXML(data);
+      res.send(xml);
+    } catch (e) {
+      res.status(500).send(e + '\n' + data);
+    }
+  }
+}
+
+function sendBodyDefault(res) {
+  res.status(406).send('Not Acceptable');
+}
+
+/**
+ * Deciding on the operation of response, function is called inside this.done()
+ */
+
+HttpContext.prototype.resolveReponseOperation = function(accepts) {
+  var result = { // default
+    sendBody : sendBodyJson,
+    contentType : 'application/json'
+  };
+  switch (accepts) {
+    case '*/*':
+    case 'application/json':
+    case 'json':
+      break;
+    case 'application/vnd.api+json':
+      result.contentType = 'application/vnd.api+json';
+      break;
+    case 'application/javascript':
+    case 'text/javascript':
+      result.sendBody = sendBodyJsonp;
+      break;
+    case 'application/xml':
+    case 'text/xml':
+    case 'xml':
+      if (accepts == 'application/xml') {
+        result.contentType = 'application/xml';
+      } else {
+        result.contentType = 'text/xml';
+      }
+      result.sendBody = sendBodyXml;
+      break;
+    default:
+      result.sendBody = sendBodyDefault;
+      result.contentType = 'text/plain';
+      break;
+  }
+  return result;
+};
+
+/**
  * Finish the request and send the correct response.
  */
 
@@ -556,55 +624,18 @@ HttpContext.prototype.done = function(cb) {
     accepts = this.req.query._format.toLowerCase();
   }
   var dataExists = typeof data !== 'undefined';
-
+  var operationResults = this.resolveReponseOperation(accepts);
+  if (!res.get('Content-Type')) {
+    res.header('Content-Type', operationResults.contentType);
+  }
   if (dataExists) {
-    switch (accepts) {
-      case '*/*':
-      case 'application/json':
-      case 'json':
-        res.json(data);
-        break;
-      case 'application/vnd.api+json':
-        res.header('Content-Type', 'application/vnd.api+json');
-        res.json(data);
-        break;
-      case 'application/javascript':
-      case 'text/javascript':
-        res.jsonp(data);
-        break;
-      case 'application/xml':
-      case 'text/xml':
-      case 'xml':
-        if (accepts === 'application/xml') {
-          res.header('Content-Type', 'application/xml');
-        } else {
-          res.header('Content-Type', 'text/xml');
-        }
-        if (data === null) {
-          res.header('Content-Length', '7');
-          res.end('<null/>');
-        } else {
-          try {
-            var xml = toXML(data);
-            res.send(xml);
-          } catch (e) {
-            res.status(500).send(e + '\n' + data);
-          }
-        }
-        break;
-      default:
-        res.status(406).send('Not Acceptable');
-        break;
-    }
+    operationResults.sendBody(res, data);
   } else {
-    if (!res.get('Content-Type')) {
-      res.header('Content-Type', 'application/json');
-    }
     if (res.statusCode === undefined || res.statusCode === 200) {
       res.statusCode = 204;
     }
-    res.end();
   }
 
+  res.end();
   cb();
 };

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -2046,6 +2046,34 @@ describe('strong-remoting-rest', function() {
       .end(done);
   });
 
+  it('returns correct content-type in an empty XML response', function(done) {
+    var method = givenSharedStaticMethod(
+      function(arg, cb) { cb(); },
+      { accepts: { arg: 'arg', type: 'Model' } });
+
+    request(app)
+      .get(method.url + '?arg={"x":1}&_format=xml')
+      .expect(204)
+      .end(function(err, res) {
+        expect(res.get('Content-type')).to.match(/xml/);
+        done();
+      });
+  });
+
+  it('defaults content-type to application/json', function(done) {
+    var method = givenSharedStaticMethod(
+      function(arg, cb) { cb(); },
+      { accepts: { arg: 'arg', type: 'Model' } });
+
+    request(app)
+      .get(method.url + '?arg={"x":1}')
+      .expect(204)
+      .end(function(err, res) {
+        expect(res.get('Content-type')).to.match(/application\/json/);
+        done();
+      });
+  });
+
   describe('client', function() {
 
     describe('call of constructor method', function() {


### PR DESCRIPTION
#### rest.test.js
- Add test case to make sure default stays as `application/json`
- Add test case to make sure it retains specified content-type

#### http-context.js
- seperate logic of figuring out what to send and sending it

Connected to strongloop/strong-remoting/issues/258