### PR TITLE
Allow source to be `formData` (=== `form`) to comply with swagger-definition

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -136,6 +136,7 @@ HttpContext.prototype.buildArgs = function(method) {
               val = ctx.req.body;
               break;
             case 'form':
+            case 'formData':
               // From the form (body)
               val = ctx.req.body && ctx.req.body[name];
               break;

--- a/lib/http-invocation.js
+++ b/lib/http-invocation.js
@@ -114,6 +114,7 @@ HttpInvocation.prototype._processArg = function(req, verb, query, accept) {
             req.body = val;
             break;
           case 'form':
+          case 'formData':
             // From the form (body)
             req.body = req.body || {};
             req.body[name] = val;

--- a/test/rest.browser.test.js
+++ b/test/rest.browser.test.js
@@ -202,6 +202,27 @@ describe('strong-remoting-rest', function() {
         });
       });
 
+      it('should allow arguments in the formData', function(done) {
+        var method = givenSharedStaticMethod(
+          function bar(a, b, cb) {
+            cb(null, a + b);
+          },
+          {
+            accepts: [
+              { arg: 'b', type: 'number', http: {source: 'formData' }  },
+              { arg: 'a', type: 'number', http: {source: 'formData' } }
+            ],
+            returns: { arg: 'n', type: 'number' },
+            http: { path: '/' }
+          }
+        );
+
+        objects.invoke(method.name, [1, 2], function(err, n) {
+          assert.equal(n, 3);
+          done();
+        });
+      });
+
       it('should respond with correct args if returns has multiple args', function(done) {
         var method = givenSharedStaticMethod(
           function(a, b, cb) {


### PR DESCRIPTION
Instead of changing the generated output (which would seem to be the better choice), I suggest allowing this as an alias. The reason is that both the [swagger generator](https://github.com/strongloop/loopback-swagger/blob/9a30a143a47445f321c1d349c5b808517e248686/lib/codegen/spec-converter.js#L81) and the swagger ui use `formData` instead of just `form`. In my opinion there is no standard that said "use `form`" and thus it was chosen at will. Migrating to `formData` would bring loopback closer to the swagger specs.