### PR TITLE
To allow user to customize the root element of xml output

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -433,19 +433,26 @@ function toJSON(input) {
   }
 }
 
-function toXML(input) {
+function toXML(input, options) {
   var xml;
+  var xmlDefaultOptions = { declaration : true };
+  var xmlOptions = util._extend(xmlDefaultOptions, options);
   if (input && typeof input.toXML === 'function') {
     xml = input.toXML();
   } else {
-    if (input) {
+    if (typeof input == 'string') {
+      //  this is a hack to handle js2xmlparser throws syntax error on string
+      //  wraps string from "a string" to "\"a string\""
+      input = JSON.stringify(input);
+    } else if (typeof input == 'object') {
       // Trigger toJSON() conversions
       input = toJSON(input);
     }
     if (Array.isArray(input)) {
       input = { result: input };
     }
-    xml = js2xmlparser('response', input, {
+    xml = js2xmlparser(xmlOptions.wrapperElement || 'response', input, {
+      declaration : { include : xmlOptions.declaration },
       prettyPrinting: {
         indentString: '  '
       },
@@ -501,13 +508,14 @@ function sendBodyJsonp(res, data) {
   res.jsonp(data);
 }
 
-function sendBodyXml(res, data) {
+function sendBodyXml(res, data, method) {
   if (data === null) {
     res.header('Content-Length', '7');
     res.send('<null/>');
   } else if (data) {
     try {
-      var xml = toXML(data);
+      var xmlOptions = method.returns[0].xml || {};
+      var xml = toXML(data, xmlOptions);
       res.send(xml);
     } catch (e) {
       res.status(500).send(e + '\n' + data);
@@ -629,7 +637,7 @@ HttpContext.prototype.done = function(cb) {
     res.header('Content-Type', operationResults.contentType);
   }
   if (dataExists) {
-    operationResults.sendBody(res, data);
+    operationResults.sendBody(res, data, method);
   } else {
     if (res.statusCode === undefined || res.statusCode === 200) {
       res.statusCode = 204;


### PR DESCRIPTION
To take wrapperElement as an option in remoteMethod setup 
```yaml
{
  returns: { 
    root: true,
      xml: {wrapperElement: 'a'}
    },
    http: { path: '/' }
}
```

Objective is to allow user to produce output as follow 
```xml
<a>1</a>
```

Fixes #262

connected to strongloop/strong-remoting/issues/262