### PR TITLE
Extract ContextBase and ctx.getScope()

### DIFF
--- a/lib/context-base.js
+++ b/lib/context-base.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var EventEmitter = require('events').EventEmitter;
+var inherits = require('util').inherits;
+
+module.exports = ContextBase;
+
+/**
+ * A base class for all Context instances
+ */
+function ContextBase(method) {
+  EventEmitter.call(this);
+
+  this.method = method;
+}
+
+inherits(ContextBase, EventEmitter);
+
+ContextBase.prototype.getScope = function() {
+  // Static methods are invoked on the constructor (this = constructor fn)
+  // Prototype methods are invoked on the instance (this = instance)
+  var method = this.method;
+  return this.instance ||
+    method.ctor ||
+    method.sharedMethod && method.sharedMethod.ctor;
+};

--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -8,11 +8,11 @@ module.exports = HttpContext;
  * Module dependencies.
  */
 
-var EventEmitter = require('events').EventEmitter;
 var debug = require('debug')('strong-remoting:http-context');
 var util = require('util');
 var inherits = util.inherits;
 var assert = require('assert');
+var ContextBase = require('./context-base');
 var Dynamic = require('./dynamic');
 var js2xmlparser = require('js2xmlparser');
 var DEFAULT_SUPPORTED_TYPES = [
@@ -43,6 +43,8 @@ var SSEClient = require('sse').Client;
  */
 
 function HttpContext(req, res, method, options) {
+  ContextBase.call(this, method);
+
   this.req = req;
   this.res = res;
   this.method = method;
@@ -71,11 +73,7 @@ function HttpContext(req, res, method, options) {
   }
 }
 
-/*!
- * Inherit from `EventEmitter`.
- */
-
-inherits(HttpContext, EventEmitter);
+inherits(HttpContext, ContextBase);
 
 HttpContext.prototype.createStream = function() {
   var streamsDesc = this.method.streams;

--- a/lib/remote-objects.js
+++ b/lib/remote-objects.js
@@ -10,6 +10,7 @@ module.exports = RemoteObjects;
 
 var EventEmitter = require('eventemitter2').EventEmitter2;
 var debug = require('debug')('strong-remoting:remotes');
+var deprecated = require('depd')('strong-remoting');
 var util = require('util');
 var urlUtil = require('url');
 var inherits = util.inherits;
@@ -609,7 +610,7 @@ RemoteObjects.prototype._executeAuthorizationHook = function(ctx, cb) {
 RemoteObjects.prototype.invokeMethodInContext = function(ctx, method, cb) {
   var self = this;
 
-  var scope = this.getScope(ctx, method);
+  var scope = ctx.getScope();
 
   self._executeAuthorizationHook(ctx, function(err) {
     if (err) return triggerErrorAndCallBack(err);
@@ -644,11 +645,10 @@ RemoteObjects.prototype.invokeMethodInContext = function(ctx, method, cb) {
  */
 
 RemoteObjects.prototype.getScope = function(ctx, method) {
-  // Static methods are invoked on the constructor (this = constructor fn)
-  // Prototype methods are invoked on the instance (this = instance)
-  return ctx.instance ||
-    method.ctor ||
-    method.sharedMethod && method.sharedMethod.ctor;
+  deprecated('remoteObjects.getScope(ctx, method) is deprecated, ' +
+    'use ctx.getScope() instead');
+  assert.equal(ctx.method, method);
+  return ctx.getScope();
 };
 
 /**

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -21,6 +21,7 @@ var bodyParser = require('body-parser');
 var cors = require('cors');
 var async = require('async');
 var HttpInvocation = require('./http-invocation');
+var ContextBase = require('./context-base');
 var HttpContext = require('./http-context');
 
 var json = bodyParser.json;
@@ -116,8 +117,9 @@ RestAdapter.prototype.invoke = function(method, ctorArgs, args, callback) {
   var invocation = new HttpInvocation(
     restMethod, ctorArgs, args, this.connection, remotes.auth
   );
-  var ctx = { req: invocation.createRequest() };
-  var scope = remotes.getScope(ctx, restMethod);
+  var ctx = new ContextBase(restMethod);
+  ctx.req = invocation.createRequest();
+  var scope = ctx.getScope();
   remotes.execHooks('before', restMethod, scope, ctx, function(err) {
     if (err) { return callback(err); }
     invocation.invoke(function(err) {
@@ -437,7 +439,7 @@ RestAdapter.prototype._invokeMethod = function(ctx, method, next) {
   if (method.rest.before) {
     steps.push(function invokeRestBefore(cb) {
       debug('Invoking rest.before for ' + ctx.methodString);
-      method.rest.before.call(remotes.getScope(ctx, method), ctx, cb);
+      method.rest.before.call(ctx.getScope(), ctx, cb);
     });
   }
 
@@ -448,7 +450,7 @@ RestAdapter.prototype._invokeMethod = function(ctx, method, next) {
   if (method.rest.after) {
     steps.push(function invokeRestAfter(cb) {
       debug('Invoking rest.after for ' + ctx.methodString);
-      method.rest.after.call(remotes.getScope(ctx, method), ctx, cb);
+      method.rest.after.call(ctx.getScope(), ctx, cb);
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "body-parser": "^1.12.4",
     "cors": "^2.6.0",
     "debug": "^2.2.0",
+    "depd": "^1.1.0",
     "eventemitter2": "^0.4.14",
     "express": "4.x",
     "inflection": "^1.7.1",


### PR DESCRIPTION
Create `ContextBase` - a base class for all Context objects where we can put methods shared by all contexts.

Move `remotes.getScope` to `ContextBase.prototype.getScope` as it belongs there more naturally and will make it easier to access scope in hooks that can access the `ctx` object only.

Connect to strongloop-internal/scrum-loopback#729

@raymondfeng @ritch please review