### PR TITLE
Fix problem afterError always called

### DIFF
--- a/lib/remote-objects.js
+++ b/lib/remote-objects.js
@@ -677,7 +677,12 @@ RemoteObjects.prototype.invokeMethodInContext = function(ctx, method, cb) {
       'Pass the method as ctx.method instead.');
   }
 
-  self.phases.run(ctx, triggerErrorAndCallBack);
+  self.phases.run(ctx, testIfErrorAndCallBack);
+
+  function testIfErrorAndCallBack(err) {
+    if (err) return triggerErrorAndCallBack(err);
+    cb();
+  }
 
   function triggerErrorAndCallBack(err) {
     ctx.error = err;


### PR DESCRIPTION
Hello everyone.

I seem to have found a bug in version 2.25.
Indeed, the afterError hook is always called even if there is no error.
https://github.com/strongloop/strong-remoting/blob/2.x-latest/lib/remote-objects.js#L680
In fact, `triggerErrorAndCallBack` method is always called because `phases.run` use `async.eachSeries` and the [documentation explain](https://github.com/caolan/async#each) 

> each(arr, iterator, [callback])
callback(err) - Optional A callback which is called when all iterator functions have finished, or an error occurs.  

In version 2.24 we had this
https://github.com/florianorpeliere/strong-remoting/blob/4d965966f4b860c27a6a42c421c7ea7e9d3696f5/lib/remote-objects.js#L625

So I allowed myself to put this piece of code in a method.
I do not know if the name really fits .

As this is my first contribution , please be indulgent .
Hoping to have helped you .