### PR TITLE
Do not call "afterError" on success

### DIFF
--- a/lib/remote-objects.js
+++ b/lib/remote-objects.js
@@ -677,14 +677,14 @@ RemoteObjects.prototype.invokeMethodInContext = function(ctx, method, cb) {
       'Pass the method as ctx.method instead.');
   }
 
-  self.phases.run(ctx, triggerErrorAndCallBack);
+  self.phases.run(ctx, function interceptInvocationErrors(err) {
+    if (!err) return cb();
 
-  function triggerErrorAndCallBack(err) {
     ctx.error = err;
     self.execHooks('afterError', method, scope, ctx, function(hookErr) {
       cb(hookErr || err);
     });
-  }
+  });
 };
 
 /**

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -2730,6 +2730,24 @@ describe('strong-remoting-rest', function() {
         });
     });
 
+    it('is not called on success', function(done) {
+      var hookCalled = false;
+      var method = givenSharedStaticMethod(function(cb) {
+        cb();
+      });
+
+      objects.afterError(method.name, function(ctx, next) {
+        hookCalled = true;
+        next();
+      });
+
+      json(method.url).end(function(err) {
+        if (err) return done(err);
+        expect(hookCalled, 'hookCalled').to.equal(false);
+        done();
+      });
+    });
+
     function verifyErrorHookIsCalled(method, expectedError, done) {
       var hookContext = 'hook not called';
 


### PR DESCRIPTION
Fix `RemoteObjects.prototype.invokeMethodInContext` to trigger afterError
hooks only when there was an invocation error.

This bug was introduced recently by #279.