### PR TITLE
Add support for "file" return args

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -15,6 +15,8 @@ var assert = require('assert');
 var ContextBase = require('./context-base');
 var Dynamic = require('./dynamic');
 var js2xmlparser = require('js2xmlparser');
+var SharedMethod = require('./shared-method');
+
 var DEFAULT_SUPPORTED_TYPES = [
     'application/json', 'application/javascript', 'application/xml',
     'text/javascript', 'text/xml',
@@ -405,6 +407,9 @@ HttpContext.prototype.setReturnArgByName = function(name, value) {
   }
 
   if (returnDesc.root) {
+    // TODO(bajtos) call SharedMethod's convertToBasicRemotingType here?
+    this.resultType = typeof returnDesc.type === 'string' ?
+      returnDesc.type.toLowerCase() : returnDesc.type;
     return;
   }
 
@@ -637,13 +642,24 @@ HttpContext.prototype.done = function(cb) {
     res.header('Content-Type', operationResults.contentType);
   }
   if (dataExists) {
-    operationResults.sendBody(res, data, method);
+    if (this.resultType !== 'file') {
+      operationResults.sendBody(res, data, method);
+      res.end();
+    } else if (Buffer.isBuffer(data) || typeof(data) === 'string') {
+      res.end(data);
+    } else if (data.pipe) {
+      data.pipe(res);
+    } else {
+      var valueType = SharedMethod.getType(data);
+      var msg = 'Cannot create a file response from "' + valueType + '"';
+      return cb(new Error(msg));
+    }
   } else {
     if (res.statusCode === undefined || res.statusCode === 200) {
       res.statusCode = 204;
     }
+    res.end();
   }
 
-  res.end();
   cb();
 };

--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -393,28 +393,30 @@ HttpContext.prototype.invoke = function(scope, method, fn, isCtor) {
 };
 
 HttpContext.prototype.setReturnArgByName = function(name, value) {
+  var ARG_WAS_HANDLED = true;
   var returnDesc = this.method.getReturnArgDescByName(name);
   var result = this.result;
   var res = this.res;
 
   if (!returnDesc) {
-    return debug('warning: cannot set return value for arg' +
+    debug('warning: cannot set return value for arg' +
       ' (%s) without description!', name);
+    return;
   }
 
   if (returnDesc.root) {
-    this.result = value;
-  } else if (returnDesc.http) {
+    return;
+  }
+
+  if (returnDesc.http) {
     switch (returnDesc.http.target) {
       case 'status':
         res.status(value);
-        break;
+        return ARG_WAS_HANDLED;
       case 'header':
         res.set(returnDesc.http.header || name, value);
-        break;
+        return ARG_WAS_HANDLED;
     }
-  } else {
-    result[name] = value;
   }
 };
 

--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -71,6 +71,10 @@ var assert = require('assert');
  * either a single argument as an object or an ordered set of arguments as an array.
  * The `err` argument is assumed; do not specify.  NOTE: Can have the same properties as
  * `accepts`, except for `http.target`.
+ *
+ * Additionally, one of the callback arguments can have `type: 'file'` and
+ * `root:true`, in which case this argument is sent in the raw form as
+ * a response body. Allowed values: `String`, `Buffer` or `ReadableStream`
  * @property {Boolean} [shared] Whether the method is shared.  Default is `true`.
  * @property {Number} [status] The default status code.
  * @end
@@ -390,6 +394,7 @@ function convertToBasicRemotingType(type) {
     case 'boolean':
     case 'buffer':
     case 'object':
+    case 'file':
     case 'any':
       return type;
     case 'array':
@@ -531,7 +536,8 @@ SharedMethod.toResult = function(returns, raw, ctx) {
     }
 
     if (item.root) {
-      result = convert(raw[index]);
+      var isFile = convertToBasicRemotingType(item.type) === 'file';
+      result = isFile ? raw[index] : convert(raw[index]);
       return false;
     }
 
@@ -539,8 +545,15 @@ SharedMethod.toResult = function(returns, raw, ctx) {
   });
 
   returns.forEach(function(item, index) {
-    var value = convert(raw[index]);
     var name = item.name || item.arg;
+    if (convertToBasicRemotingType(item.type) === 'file') {
+      console.warn('%s: discarded non-root return argument %s of type "file"',
+        this.stringName,
+        name);
+      return;
+    }
+
+    var value = convert(raw[index]);
     result[name] = value;
   });
 

--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -526,9 +526,12 @@ SharedMethod.toResult = function(returns, raw, ctx) {
       return false;
     }
 
+    if (ctx && ctx.setReturnArgByName(item.name || item.arg, raw[index])) {
+      return false;
+    }
+
     if (item.root) {
       result = convert(raw[index]);
-      if (ctx) ctx.setReturnArgByName(item.name || item.arg, raw[index]);
       return false;
     }
 
@@ -539,7 +542,6 @@ SharedMethod.toResult = function(returns, raw, ctx) {
     var value = convert(raw[index]);
     var name = item.name || item.arg;
     result[name] = value;
-    if (ctx) ctx.setReturnArgByName(name, value);
   });
 
   return result;

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -2046,20 +2046,47 @@ describe('strong-remoting-rest', function() {
 
   describe('result args as headers', function() {
     it('sets the header using the callback arg', function(done) {
-      var val = 'foobar';
+      var A_STRING_VALUE = 'foobar';
       var method = givenSharedStaticMethod(
         function fn(input, cb) {
-          cb(null, input);
+          cb(null, input, input);
         },
         {
           accepts: {arg: 'input', type: 'string'},
-          returns: {arg: 'output', type: 'string', http: { target: 'header' } }
+          returns: [
+            {arg: 'value', type: 'string' },
+            {arg: 'output', type: 'string', http: { target: 'header' } }
+          ]
         }
       );
-      json(method.url + '?input=' + val)
-        .expect('output', val)
-        .expect(200, done);
+      json(method.url + '?input=' + A_STRING_VALUE)
+        .expect(200)
+        .expect('output', A_STRING_VALUE)
+        .expect({ value: A_STRING_VALUE })
+        .end(done);
     });
+
+    it('sets the header using the callback arg - root arg', function(done) {
+      var A_STRING_VALUE = 'foobar';
+      var method = givenSharedStaticMethod(
+        function fn(input, cb) {
+          cb(null, { value: input }, input);
+        },
+        {
+          accepts: {arg: 'input', type: 'string'},
+          returns: [
+            {arg: 'value', type: 'object', root: true },
+            {arg: 'output', type: 'string', http: { target: 'header' } }
+          ]
+        }
+      );
+      json(method.url + '?input=' + A_STRING_VALUE)
+        .expect(200)
+        .expect('output', A_STRING_VALUE)
+        .expect({ value: A_STRING_VALUE })
+        .end(done);
+    });
+
     it('sets the custom header using the callback arg', function(done) {
       var val = 'foobar';
       var method = givenSharedStaticMethod(


### PR DESCRIPTION
1) Fix handling of return args with `http.target:header`.  Arguments mapped to a response http header should not be included in the response body.

2) Allow users to specify `{ type: 'file', root: true }` for the single argument that will be sent directly as the response body.

The following values are supported for file the file argument:
 - String
 - Buffer
 - ReadableStream (anything that exposes .pipe() method)

Example usage:

```js
MyModel.download = function(cb) {
  // this can be for example http.request()
  getTheStreamBody(function(err, stream) {
    if (err) return cb(err);
    // stream can be any of: string, buffer, ReadableStream (e.g. http.IncomingMessage)
    cb(null, stream, 'application/octet-stream');
  });
}

MyModel.remoteMethod('download', {
  isStatic: true,
  returns: [
    { arg: 'body', type: 'file', root: true },
    { arg: 'Content-Type', type: 'string', http: { target: 'header' } },
  ],
});
```

Fix strongloop/loopback#2063
Connect to #35 

/to @ritch please review
/cc @raymondfeng @STRML 