### PR TITLE
Fix typo 'opionated' to 'opinionated'

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Collections that are the result of require('strong-remoting').create() are respo
 
 ### Adapters
 
-Adapters provide the transport-specific mechanisms to make remote objects (and collections thereof) available over their transport. The REST adapter, for example, handles an HTTP server and facilitates mapping your objects to RESTful resources. Other adapters, on the other hand, might provide a less opionated, RPC-style network interface. Your application code doesn't need to know what adapter it's using.
+Adapters provide the transport-specific mechanisms to make remote objects (and collections thereof) available over their transport. The REST adapter, for example, handles an HTTP server and facilitates mapping your objects to RESTful resources. Other adapters, on the other hand, might provide a less opinionated, RPC-style network interface. Your application code doesn't need to know what adapter it's using.
 
 ### Hooks
 

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -1974,7 +1974,7 @@ describe('strong-remoting-rest', function() {
   });
 
   describe('status codes', function() {
-    describe('using a custom satus code', function() {
+    describe('using a custom status code', function() {
       it('returns a custom status code', function(done) {
         var method = givenSharedStaticMethod(
           function fn(cb) {
@@ -2038,7 +2038,7 @@ describe('strong-remoting-rest', function() {
         .expect(404, done);
     });
 
-    it('returns 404 with standard JSON body for uknown URL', function(done) {
+    it('returns 404 with standard JSON body for unknown URL', function(done) {
       json('/unknown-url')
         .expect(404)
         .end(expectErrorResponseContaining({status: 404}, done));


### PR DESCRIPTION
Fix typo 'opionated' to 'opinionated'
Should fix doc too.
https://docs.strongloop.com/display/public/LB/Strong+Remoting