### PR TITLE
[SEMVER-MAJOR] Don't send Access-Control-Allow-Credentials by default.

### DIFF
--- a/lib/jsonrpc-adapter.js
+++ b/lib/jsonrpc-adapter.js
@@ -137,7 +137,7 @@ JsonRpcAdapter.prototype.createHandler = function() {
   debug('remoting options: %j', this.remotes.options);
   var jsonOptions = this.remotes.options.json || { strict: false };
   var corsOptions = this.remotes.options.cors;
-  if (corsOptions === undefined) corsOptions = { origin: true, credentials: true };
+  if (corsOptions === undefined) corsOptions = { origin: true, credentials: false };
 
   // Optimize the cors handler
   var corsHandler = function(req, res, next) {

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -236,7 +236,7 @@ RestAdapter.prototype.createHandler = function() {
   }
   var jsonOptions = this.remotes.options.json || { strict: false };
   var corsOptions = this.remotes.options.cors;
-  if (corsOptions === undefined) corsOptions = { origin: true, credentials: true };
+  if (corsOptions === undefined) corsOptions = { origin: true, credentials: false };
 
   // Optimize the cors handler
   var corsHandler = function(req, res, next) {

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -339,8 +339,11 @@ describe('strong-remoting-rest', function() {
         .set('Origin', 'http://localhost:3001')
         .send({ person: 'ABC' })
         .expect('Access-Control-Allow-Origin', 'http://localhost:3001')
-        .expect('Access-Control-Allow-Credentials', 'true')
-        .expect(200, done);
+        .expect(200)
+        .end(function(err, res) {
+          assert(res.get('Access-Control-Allow-Credentials') === undefined);
+          done();
+        });
     });
 
     it('should skip cors if origin is the same as the request url', function(done) {
@@ -352,8 +355,8 @@ describe('strong-remoting-rest', function() {
         .set('Origin', url)
         .send({ person: 'ABC' })
         .end(function(err, res) {
-          assert(res.headers['Access-Control-Allow-Origin'] === undefined);
-          assert(res.headers['Access-Control-Allow-Credentials'] === undefined);
+          assert(res.get('Access-Control-Allow-Origin') === undefined);
+          assert(res.get('Access-Control-Allow-Credentials') === undefined);
           done();
         });
     });
@@ -365,8 +368,11 @@ describe('strong-remoting-rest', function() {
         .set('Origin', 'http://localhost:3001')
         .send()
         .expect('Access-Control-Allow-Origin', 'http://localhost:3001')
-        .expect('Access-Control-Allow-Credentials', 'true')
-        .expect(204, done);
+        .expect(204)
+        .end(function(err, res) {
+          assert(res.get('Access-Control-Allow-Credentials') === undefined);
+          done();
+        });
     });
 
     it('should support cors when errors happen', function(done) {
@@ -376,8 +382,11 @@ describe('strong-remoting-rest', function() {
         .set('Origin', 'http://localhost:3001')
         .send({ person: 'error' })
         .expect('Access-Control-Allow-Origin', 'http://localhost:3001')
-        .expect('Access-Control-Allow-Credentials', 'true')
-        .expect(400, done);
+        .expect(400)
+        .end(function(err, res) {
+          assert(res.get('Access-Control-Allow-Credentials') === undefined);
+          done();
+        });
     });
 
     it('should support cors when parsing errors happen', function(done) {
@@ -387,8 +396,11 @@ describe('strong-remoting-rest', function() {
         .set('Origin', 'http://localhost:3001')
         .send('ABC') // invalid json
         .expect('Access-Control-Allow-Origin', 'http://localhost:3001')
-        .expect('Access-Control-Allow-Credentials', 'true')
-        .expect(400, done);
+        .expect(400)
+        .end(function(err, res) {
+          assert(res.get('Access-Control-Allow-Credentials') === undefined);
+          done();
+        });
     });
 
     it('OPTIONS requests should skip cors if config is false', function(done) {


### PR DESCRIPTION
This is a very dangerous header to be sending. Given that strong-remoting/loopback encourages the use of `accessToken` cookies, I see no reason why we should not have secure defaults and make the user decide whether or not to open this vector.