### PR TITLE
allow disabling sketchy string coercion in config

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -201,7 +201,7 @@ HttpContext.prototype.buildArgs = function(method) {
     }
 
     // Coerce dynamic args when input is a string.
-    if (isAny && typeof val === 'string') {
+    if (isAny && typeof val === 'string' && this.options.coerce !== false) {
       val = coerceAll(val);
     }
 

--- a/test/http-context.test.js
+++ b/test/http-context.test.js
@@ -79,6 +79,12 @@ describe('HttpContext', function() {
         input: '000123',
         expectedValue: '000123',
       }));
+      it('skips coercion on "any" if user asks for it', givenMethodExpectArg({
+        type: 'any',
+        input: '200000000000000000000001',
+        expectedValue: '200000000000000000000001',
+        options: { coerce: false },
+      }));
     });
 
     describe('arguments with custom type', function() {
@@ -110,7 +116,7 @@ function givenMethodExpectArg(options) {
     var app = require('express')();
 
     app.get('/', function(req, res) {
-      var ctx = new HttpContext(req, res, method);
+      var ctx = new HttpContext(req, res, method, options.options);
       try {
         expect(ctx.args.testArg).to.eql(options.expectedValue);
       } catch (e) {


### PR DESCRIPTION
Re: https://github.com/strongloop/loopback/issues/1217, https://github.com/strongloop/loopback/pull/1221, https://github.com/strongloop/strong-remoting/issues/299, etc. Ran into this bug yet again today. This coercion of string params is a major antipattern if you're using mongodb and there really needs to be a way to opt out of it.