### PR TITLE
Test rest coercion

### DIFF
--- a/test/rest-coercion.test.js
+++ b/test/rest-coercion.test.js
@@ -1,0 +1,158 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var debug = require('debug')('test');
+var expect = require('chai').expect;
+var express = require('express');
+var fs = require('fs');
+var supertest = require('supertest');
+var path = require('path');
+
+var RemoteObjects = require('..');
+
+describe('Coercion in RestAdapter', function() {
+  var ctx = {
+    remoteObject: null,
+    request: null,
+    ERROR_BAD_REQUEST: new Error(400),
+    prettyExpectation: prettyExpectation,
+    verifyResultOnResponse: verifyResultOnResponse,
+    runtime: {
+      _reportData: {},
+      currentSuiteName: null,
+      currentInput: null,
+    },
+  };
+
+  before(setupRemoteServer);
+  beforeEach(setupRemoteObjects);
+  after(stopRemoteServer);
+  after(writeReport);
+
+  loadAllTestFiles();
+
+  /***** IMPLEMENTATION DETAILS *****/
+
+  var server; // eslint-disable-line one-var
+  function setupRemoteServer(done) {
+    var app = express();
+    app.use(function(req, res, next) {
+      // create the handler for each request
+      ctx.remoteObjects.handler('rest').apply(ctx.remoteObjects, arguments);
+    });
+    server = app.listen(0, '127.0.0.1', function() {
+      ctx.request = supertest('http://127.0.0.1:' + this.address().port);
+      done();
+    });
+    server.on('error', done);
+  }
+
+  function stopRemoteServer() {
+    server.close();
+  }
+
+  function setupRemoteObjects() {
+    ctx.remoteObjects = RemoteObjects.create({
+      errorHandler: { debug: true, log: false },
+    });
+  }
+
+  function loadAllTestFiles() {
+    var _describe = global.describe;
+    describe = function(name, fn) {
+      _describe.call(this, name, function() {
+        beforeEach(function() {
+          ctx.runtime.currentSuiteName = name;
+          ctx.runtime.currentInput = undefined;
+        });
+        fn.apply(this, arguments);
+      });
+    };
+
+    var testRoot = path.resolve(__dirname, 'rest-coercion');
+    var testFiles = fs.readdirSync(testRoot);
+    testFiles = testFiles.filter(function(it) {
+      return /\.suite\.js$/.test(it) &&
+        !!require.extensions[path.extname(it).toLowerCase()];
+    });
+
+    for (var ix in testFiles) {
+      var name = testFiles[ix];
+      var fullPath = path.resolve(testRoot, name);
+      debug('Loading test suite %s (%s)', name, fullPath);
+      require(fullPath)(ctx);
+    }
+
+    describe = _describe;
+  }
+
+  function prettyExpectation(expectedValue) {
+    if (expectedValue instanceof Error)
+      return 'HTTP error ' + expectedValue.message;
+    if (Array.isArray(expectedValue))
+      return '[' + expectedValue.map(prettyExpectation).join(', ') + ']';
+    if (expectedValue instanceof Date)
+      return isNaN(expectedValue.valueOf()) ?
+        '<Invalid Date>' : '<Date: ' + expectedValue.toJSON() + '>';
+    return JSON.stringify(expectedValue);
+  }
+
+  function verifyResultOnResponse(err, res, actualValue, expectedResult, done) {
+    if (err && !res) return done(err);
+    var actual = res.statusCode === 200 ?
+      { value: actualValue } :
+      { error: res.statusCode };
+
+    var expected = expectedResult instanceof Error ?
+      { error: +expectedResult.message } :
+      { value: expectedResult };
+
+    var suiteName = ctx.runtime.currentSuiteName;
+    var input = ctx.runtime.currentInput;
+    if (suiteName && input) {
+      var reportData = ctx.runtime._reportData;
+      if (!reportData[suiteName])
+        reportData[suiteName] = {};
+      if (input in reportData[suiteName])
+        return done(new Error('DUPLICATE TEST CASE: ' + input));
+      reportData[suiteName][input] = actual;
+    }
+
+    expect(actual).to.eql(expected);
+    done();
+  }
+
+  function writeReport() {
+    var rows = [];
+    var reportData = ctx.runtime._reportData;
+    for (var sn in reportData) { // eslint-disable-line one-var
+      var suite = reportData[sn];
+      for (var tc in suite) { // eslint-disable-line one-var
+        var result = suite[tc];
+        result = result.error ?
+           '<HTTP Error ' + result.error  + '>' :
+           stringify(result.value);
+        rows.push([sn, tc, result].join('\t'));
+      }
+    }
+
+    var report = rows.join('\n') + '\n';
+    var filePath = path.resolve(__dirname, 'rest-coercion/report.csv');
+    fs.writeFileSync(filePath, report);
+
+    function stringify(value) {
+      if (Array.isArray(value))
+        return '[' + value.map(stringify).join(', ') + ']';
+      if (value instanceof Date)
+        return isNaN(value.valueOf()) ?
+          '<Invalid Date>' : '<Date: ' + value.toJSON() + '>';
+      if (value === undefined)
+        return '<undefined>';
+      return JSON.stringify(value);
+    }
+  }
+});

--- a/test/rest-coercion/README.md
+++ b/test/rest-coercion/README.md
@@ -1,0 +1,82 @@
+# Test coercion of input arguments in REST adapter
+
+The tests are grouped based on where the input argument is read from
+and what is the content-type of that source.
+
+After the tests finish, a CSV report is written in `report.csv`. This report
+makes it easy to compare results between different strong-remoting versions,
+just run `diff -du report1.csv report2.csv`.
+
+## Query string
+
+Arg spec: `{ arg: 'arg', http: { source: 'query' } }`
+
+Example request:
+
+```http
+GET /api?arg=value&arg2=value2 HTTP/1.1
+```
+
+See `urlencoded-*.suite.js` for tests.
+
+## URL-encoded form
+
+Arg spec: `{ arg: 'arg', http: { source: 'form' } }`
+
+Example request:
+
+```http
+POST /api HTTP/1.1
+Content-Type: application/x-www-form-urlencoded
+
+arg=value&arg2=value2
+```
+
+See `urlencoded-*.suite.js` for test cases.
+
+## JSON-encoded form
+
+Arg spec: `{ arg: 'arg', http: { source: 'form' } }`
+
+Example request:
+
+```http
+POST /api HTTP/1.1
+Content-Type: application/json
+
+{
+  "arg": "value",
+  "arg2": "value2"
+}
+```
+
+See `jsonform-*.suite.js` for test cases.
+
+## JSON-encoded body
+
+Arg spec: `{ arg: 'arg', http: { source: 'body' } }`
+
+Example request:
+
+```http
+POST /api HTTP/1.1
+Content-Type: application/json
+
+{
+  "name": "Superb",
+  "maker": "Skoda"
+}
+```
+
+See `jsonbody-*.suite.js` for test cases.
+
+The difference between JSON form and body is that the argument is set to full
+request body argument's http `source` is `body`.
+
+## URL-encoded body
+
+We don't have coverage for this scenario yet.
+
+## URL path parameters
+
+We don't have coverage for this scenario yet.

--- a/test/rest-coercion/_jsonbody.context.js
+++ b/test/rest-coercion/_jsonbody.context.js
@@ -1,0 +1,92 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var debug = require('debug')('test');
+var expect = require('chai').expect;
+var util = require('util');
+var format = util.format;
+var extend = util._extend;
+
+module.exports = function createJsonBodyContext(ctx) {
+  return extend({
+    verifyTestCases: verifyTestCases,
+  }, ctx);
+
+  /**
+   * Verify a set of test-cases for a given argument specification
+   * (remoting definition).
+   *
+   * @param {Object} argSpec Argument definition, note that `http`
+   *   settings are injected automatically.
+   * @param {Array} testCases List of test cases to run & verify.
+   *   A test-case is a tuple [request-body, expected-argument-value]
+   *   The second item is optional, meaning the response should be the same
+   *   as the request.
+   *
+   * **Example**
+   *
+   * ```js
+   * verifyTestCases({ arg: 'name', type: 'any' }, [
+   *   [{ txt: null }],
+   *   [{ num: 1}, ERROR_BAD_REQUEST]
+   * ]);
+   * ```
+   *
+   * In this scenario, we build a shared method that accepts a single "name"
+   * argument of "any" type. Then we run two test cases:
+   *
+   * The first one sends JSON request body `{ "txt": null }` and expects
+   * the argument to be set to `{ arg: null }` (the same value).
+   *
+   * The second one sends JSON request body `{ "num": 1 }` and expects
+   * the request to fail with HTTP status 400 Bad Request.
+   */
+  function verifyTestCases(argSpec, testCases) {
+    testCases.forEach(function(tc) {
+      var requestBody = tc[0];
+      var expectedValue = tc[1];
+      if (tc.length < 2)
+        expectedValue = requestBody;
+
+      // supertests sends string data verbatim
+      var niceInput = typeof requestBody === 'string' ?
+        requestBody : JSON.stringify(requestBody);
+      var niceExpectation = ctx.prettyExpectation(expectedValue);
+      var testName = format('coerces %s to %s', niceInput, niceExpectation);
+
+      it(testName, function(done) {
+        ctx.runtime.currentInput = niceInput;
+        testCoercion(argSpec, requestBody, expectedValue, done);
+      });
+    });
+  }
+
+  function testCoercion(argSpec, requestBody, expectedResult, done) {
+    var argValue;
+    var testClass = ctx.remoteObjects.exports.testClass = {
+      testMethod: function(arg, cb) {
+        argValue = arg;
+        return cb(null, true);
+      },
+    };
+
+    extend(testClass.testMethod, {
+      shared: true,
+      accepts: extend(argSpec, { http: { source: 'body' }}),
+      returns: { name: 'success', type: 'boolean' },
+    });
+
+    ctx.request.get('/testClass/testMethod')
+      .set('Accept', 'application/json')
+      .set('Content-Type', 'application/json')
+      .send(requestBody)
+      .expect('Content-Type', /json/)
+      .end(function(err, res) {
+        ctx.verifyResultOnResponse(err, res, argValue, expectedResult, done);
+      });
+  }
+};

--- a/test/rest-coercion/_jsonform.context.js
+++ b/test/rest-coercion/_jsonform.context.js
@@ -1,0 +1,91 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var debug = require('debug')('test');
+var expect = require('chai').expect;
+var util = require('util');
+var format = util.format;
+var extend = util._extend;
+
+var EMPTY_BODY = {};
+
+module.exports = function createJsonBodyContext(ctx) {
+  return extend({
+    /** Send a request with an empty body (that is still valid JSON) */
+    EMPTY_BODY: EMPTY_BODY,
+    verifyTestCases: verifyTestCases,
+  }, ctx);
+
+  /**
+   * Verify a set of test-cases for a given argument specification
+   * (remoting definition).
+   *
+   * @param {Object} argSpec Argument definition, note that `http`
+   *   settings are injected automatically.
+   * @param {Array} testCases List of test cases to run & verify.
+   *   A test-case is a tuple [request-body, expected-argument-value]
+   *
+   * **Example**
+   *
+   * ```js
+   * verifyTestCases({ arg: 'arg', type: 'number' }, [
+   *   [{ arg: null }, 0],
+   *   [{ arg: 'text' }, ERROR_BAD_REQUEST]
+   * ]);
+   * ```
+   *
+   * In this scenario, we build a shared method that accepts a single "arg"
+   * argument of "number" type. Then we run two test cases:
+   *
+   * The first one sends JSON request body `{ "arg": null }` and expects
+   * the argument to be set to number `0`.
+   *
+   * The second one sends JSON request body `{ "arg": 'text' }` and expects
+   * the request to fail with HTTP status 400 Bad Request.
+   */
+  function verifyTestCases(argSpec, testCases) {
+    testCases.forEach(function(tc) {
+      var requestBody = tc[0];
+      var expectedValue = tc[1];
+
+      var niceInput = requestBody === EMPTY_BODY ?
+        'empty body' : JSON.stringify(requestBody);
+      var niceExpectation = ctx.prettyExpectation(expectedValue);
+      var testName = format('coerces %s to %s', niceInput, niceExpectation);
+
+      it(testName, function(done) {
+        ctx.runtime.currentInput = niceInput;
+        testCoercion(argSpec, requestBody, expectedValue, done);
+      });
+    });
+  }
+
+  function testCoercion(argSpec, requestBody, expectedResult, done) {
+    var argValue;
+    var testClass = ctx.remoteObjects.exports.testClass = {
+      testMethod: function(arg, cb) {
+        argValue = arg;
+        return cb(null, true);
+      },
+    };
+
+    extend(testClass.testMethod, {
+      shared: true,
+      accepts: extend(argSpec, { http: { source: 'form' }}),
+      returns: { name: 'success', type: 'boolean' },
+    });
+
+    ctx.request.get('/testClass/testMethod')
+      .set('Accept', 'application/json')
+      .set('Content-Type', 'application/json')
+      .send(requestBody)
+      .expect('Content-Type', /json/)
+      .end(function(err, res) {
+        ctx.verifyResultOnResponse(err, res, argValue, expectedResult, done);
+      });
+  }
+};

--- a/test/rest-coercion/_urlencoded.context.js
+++ b/test/rest-coercion/_urlencoded.context.js
@@ -1,0 +1,105 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var debug = require('debug')('test');
+var expect = require('chai').expect;
+var util = require('util');
+var format = util.format;
+var extend = util._extend;
+
+var EMPTY_QUERY = '';
+
+module.exports = function createUrlEncodedContext(ctx, target) {
+  return extend({
+    /** Send empty data, i.e. empty request body or no query string */
+    EMPTY_QUERY: EMPTY_QUERY,
+    verifyTestCases: verifyTestCases,
+  }, ctx);
+
+  var TARGET_QUERY_STRING = target === 'qs';
+
+  /**
+   * Verify a set of test-cases for a given argument specification
+   * (remoting definition).
+   *
+   * @param {Object} argSpec Argument definition, note that `http`
+   *   settings are injected automatically.
+   * @param {Array} testCases List of test cases to run & verify.
+   *   A test-case is a tuple [request-body, expected-argument-value]
+   *
+   * **Example**
+   *
+   * ```js
+   * verifyTestCases({ arg: 'arg', type: 'number' }, [
+   *   [{ arg: 0 }, 0],
+   *   [{ arg: 'text' }, ERROR_BAD_REQUEST]
+   * ]);
+   * ```
+   *
+   * In this scenario, we build a shared method that accepts a single "arg"
+   * argument of "number" type. Then we run two test cases:
+   *
+   * The first one sends url-encoded data `arg=0` either in query-string
+   * or request body (depending on `target` configuration set earlier)
+   * and expects the argument to be set to number `0`.
+   *
+   * The second one sends `arg=text` and expects the request to fail
+   * with HTTP status 400 Bad Request.
+   */
+  function verifyTestCases(argSpec, testCases) {
+    testCases.forEach(function(tc) {
+      var queryString = tc[0];
+      var expectedValue = tc[1];
+
+      var niceInput = queryString === EMPTY_QUERY ?
+        TARGET_QUERY_STRING ? 'empty query' : 'empty form' :
+        queryString;
+      var niceExpectation = ctx.prettyExpectation(expectedValue);
+      var testName = format('coerces %s to %s', niceInput, niceExpectation);
+
+      it(testName, function(done) {
+        ctx.runtime.currentInput = niceInput;
+        testCoercion(argSpec, queryString, expectedValue, done);
+      });
+    });
+  }
+
+  function testCoercion(argSpec, queryString, expectedResult, done) {
+    var argValue;
+    var testClass = ctx.remoteObjects.exports.testClass = {
+      testMethod: function(arg, cb) {
+        argValue = arg;
+        return cb(null, true);
+      },
+    };
+
+    var source = TARGET_QUERY_STRING ? 'query' : 'form';
+    extend(testClass.testMethod, {
+      shared: true,
+      accepts: extend(argSpec, { http: { source: source }}),
+      returns: { name: 'success', type: 'boolean' },
+    });
+
+    var uri = '/testClass/testMethod';
+    var chain; // eslint-disable-line one-var
+    if (TARGET_QUERY_STRING) {
+      uri = uri + '?' + queryString;
+      chain = ctx.request.get(uri);
+    } else {
+      chain = ctx.request.post(uri)
+        .type('form')
+        .send(queryString);
+    }
+
+    chain
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .end(function(err, res) {
+        ctx.verifyResultOnResponse(err, res, argValue, expectedResult, done);
+      });
+  }
+};

--- a/test/rest-coercion/jsonbody-any.suite.js
+++ b/test/rest-coercion/jsonbody-any.suite.js
@@ -1,0 +1,131 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var jsonBodyContext = require('./_jsonbody.context');
+
+module.exports = function(ctx) {
+  ctx = jsonBodyContext(ctx);
+  var ERROR_BAD_REQUEST = ctx.ERROR_BAD_REQUEST;
+  var verifyTestCases = ctx.verifyTestCases;
+
+  describe('json body - any - required', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'anyname', type: 'any', required: true }, [
+      [null, null], // should be: ERROR_BAD_REQUEST
+      // Both empty array and empty object are valid values for "any"
+      [[]],
+      [{}],
+      // Other valid values
+      [false],
+      [1],
+      // To send a string in a JSON body, one has to manually encode it,
+      // because supertest sends string data verbatim
+      ['"text"', 'text'],
+      [{ x: null }],
+      [[1]],
+    ]);
+  });
+
+  describe('json body - any - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'anyname', type: 'any' }, [
+      // Empty values
+      [null, null],
+
+      // Valid values
+      [false],
+      [1],
+      ['"text"', 'text'],
+
+      // Dates are not recognized/parsed
+      ['"2016-05-19T13:28:51.299Z"', '2016-05-19T13:28:51.299Z'],
+
+      [[]],
+      [{}],
+
+      // Verify that deep coercion is not triggered
+      // and types specified in JSON are preserved
+
+      [{ x: null }],
+      [[null]],
+      [{ x: 'null' }],
+      [['null']],
+
+      [{ x: false }],
+      [[false]],
+      [{ x: 'false' }],
+      [['false']],
+
+      [{ x: '' }],
+      [['']],
+
+
+      [{ x: true }],
+      [[true]],
+      [{ x: 'true' }],
+      [['true']],
+
+      [{ x: 0 }],
+      [[0]],
+      [{ x: '0' }],
+      [['0']],
+
+      [{ x: 1 }],
+      [[1]],
+      [{ x: '1' }],
+      [['1']],
+
+      [{ x: -1 }],
+      [[-1]],
+      [{ x: '-1' }],
+      [['-1']],
+
+      [{ x: 1.2 }],
+      [[1.2]],
+      [{ x: '1.2' }],
+      [['1.2']],
+
+      [{ x: -1.2 }],
+      [[-1.2]],
+      [{ x: '-1.2' }],
+      [['-1.2']],
+
+      [{ x: 'text' }],
+      [['text']],
+
+      [{ x: [] }],
+      [[[]]],
+      [{ x: '[]' }],
+      [['[]']],
+
+      [{ x: {}}],
+      [[{}]],
+      [{ x: '{}' }],
+      [['{}']],
+
+      // Numeric strings larger than MAX_SAFE_INTEGER
+      [{ x: '2343546576878989879789' }],
+      [['2343546576878989879789']],
+      [{ x: '-2343546576878989879789' }],
+      [['-2343546576878989879789']],
+
+      // Strings mimicking scientific notation
+      [{ x: '1.234e+30' }],
+      [['1.234e+30']],
+      [{ x: '-1.234e+30' }],
+      [['-1.234e+30']],
+
+      // Should `any` recognize date?
+      [{ x: '2016-05-19T13:28:51.299Z' }],
+      [['2016-05-19T13:28:51.299Z']],
+      [{ x: '2016-05-19' }],
+      [['2016-05-19']],
+      [{ x: 'Thu May 19 2016 15:28:51 GMT 0200 (CEST)' }],
+      [['Thu May 19 2016 15:28:51 GMT 0200 (CEST)']],
+    ]);
+  });
+};

--- a/test/rest-coercion/jsonbody-array.suite.js
+++ b/test/rest-coercion/jsonbody-array.suite.js
@@ -1,0 +1,235 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var jsonBodyContext = require('./_jsonbody.context');
+
+var INVALID_DATE = new Date(NaN);
+
+module.exports = function(ctx) {
+  ctx = jsonBodyContext(ctx);
+  var ERROR_BAD_REQUEST = ctx.ERROR_BAD_REQUEST;
+  var verifyTestCases = ctx.verifyTestCases;
+
+  describe('json body - array - required', function() {
+    // The exact type is not important to test how required array parameters
+    // treat missing values, therefore we test a single type (boolean) only.
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'anyname', type: ['boolean'], required: true }, [
+      // valid values
+      [[]], // an empty array is a valid value for required array
+      [[true, false]],
+      // invalid values - should trigger ERROR_BAD_REQUEST
+      [null, [false]], // should be: ERROR_BAD_REQUEST
+    ]);
+  });
+
+  describe('json body - array of booleans - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'anyname', type: ['boolean'] }, [
+      // empty array
+      [[]],
+
+      // valid values
+      [[false], [false]],
+      [[true], [true]],
+      [[true, false], [true, false]],
+
+      // Value is not an array - should return ERROR_BAD_REQUEST
+      [null, [false]],
+      [false, [false]],
+      [true, [true]],
+      [0, [false]],
+      [1, [true]],
+      [2, [true]],
+      [-1, [true]],
+      ['"text"', [true]],
+      [{}, [true]],
+
+      // Array items have wrong type - should return ERROR_BAD_REQUEST
+      [[null], [false]],
+      [['true', 'false'], [true, false]],
+      [['0'], [false]],
+      [['1'], [true]],
+      [['2'], [true]],
+      [['-1'], [true]],
+      [['text'], [true]],
+      [[{}], [true]],
+      [[[]], [true]],
+    ]);
+  });
+
+  describe('json body - array of numbers - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'anyname', type: ['number'] }, [
+      // empty array
+      [[]],
+
+      // Valid values
+      [[0]],
+      [[1]],
+      [[-1]],
+      [[0, 2, -2]],
+      [[1.2, -1.2]],
+      // Numbers larger than MAX_SAFE_INTEGER get trimmed
+      [[2343546576878989879789], [2.34354657687899e+21]],
+      [[-2343546576878989879789], [-2.34354657687899e+21]],
+      // Scientific notation
+      [[1.234e+30], [1.234e+30]],
+      [[-1.234e+30], [-1.234e+30]],
+
+      // Value is not an array - should return ERROR_BAD_REQUEST
+      [null, [0]],
+      [false, [0]],
+      [true, [1]],
+      [0, [0]],
+      ['"0"', [0]],
+      [1, [1]],
+      ['"1"', [1]],
+      [-1, [-1]],
+      ['"-1"', [-1]],
+      [1.2, [1.2]],
+      ['"1.2"', [1.2]],
+      [-1.2, [-1.2]],
+      ['"-1.2"', [-1.2]],
+      ['"text"', ERROR_BAD_REQUEST],
+      [{}, ERROR_BAD_REQUEST],
+      [{ x: true }, ERROR_BAD_REQUEST],
+
+      // Array items have wrong type - should return ERROR_BAD_REQUEST
+      [[null], [0]],
+      [[true], [1]],
+      [['0'], [0]],
+      [['1'], [1]],
+      [['-1'], [-1]],
+      [['1.2'], [1.2]],
+      [['-1.2'], [-1.2]],
+      [['text'], ERROR_BAD_REQUEST],
+      [[1, 'text'], ERROR_BAD_REQUEST],
+    ]);
+  });
+
+  describe('json body - array of strings - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'anyname', type: ['string'] }, [
+      // Empty array
+      [[]],
+
+      // Valid values
+      [['']],
+      [['text']],
+      [['one', 'two']],
+
+      // Value is not an array - should return ERROR_BAD_REQUEST
+      [null, ['null']],
+      [false, ['false']],
+      [true, ['true']],
+      [0, ['0']],
+      [1, ['1']],
+      ['"text"', ['text']],
+      [{}, ['[object Object]']],
+
+      // Array items have wrong type - should return ERROR_BAD_REQUEST
+      [[null], ['null']],
+      [[1], ['1']],
+      [[true], ['true']],
+      [[{}], ['[object Object]']],
+      [[[]], ['']],
+    ]);
+  });
+
+  describe('json body - array of dates - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'anyname', type: ['date'] }, [
+      // Empty array
+      [[]],
+
+      // Valid values
+      [[0], [new Date(0)]],
+      [['0'], [new Date('0')]], // 1999-12-31T23:00:00.000Z in CEST
+      [[1], [new Date(1)]],
+      [['1'], [new Date('1')]], // 2000-12-31T23:00:00.000Z
+      [['2016-05-19T13:28:51.299Z'],
+        [new Date('2016-05-19T13:28:51.299Z')]],
+      [['2016-05-19T13:28:51.299Z', '2016-05-20T08:27:28.539Z'], [
+        new Date('2016-05-19T13:28:51.299Z'),
+        new Date('2016-05-20T08:27:28.539Z'),
+      ]],
+
+      // Value is not an array - should return ERROR_BAD_REQUEST
+      [null, [new Date(0)]],
+      [false, [new Date(0)]],
+      [true, [new Date(1)]],
+      ['text', ERROR_BAD_REQUEST],
+      ['2016-05-19T13:28:51.299Z', ERROR_BAD_REQUEST],
+
+      // Array items have wrong type - should return ERROR_BAD_REQUEST
+      [[null], [new Date(0)]],
+      [[false], [new Date(0)]],
+      [[true], [new Date(1)]],
+      [['text'], [INVALID_DATE]],
+    ]);
+  });
+
+  describe('json body - array of any - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'anyname', type: ['any'] }, [
+      // Empty array
+      [[]],
+
+      // Valid values - booleans
+      [[true, false]],
+
+      // Valid values - numbers
+      [[0]],
+      [[1]],
+      [[-1]],
+      [[0, 2, -2]],
+      [[1.2, -1.2]],
+
+      // Valid values - dates - should we coerce?
+      [['2016-05-19T13:28:51.299Z'],
+        ['2016-05-19T13:28:51.299Z']],
+
+      // Valid values - strings
+      [['text']],
+
+      // Boolean-line strings should not be coerced
+      [['true']],
+
+      // Number-like strings should not be coerced
+      [['0']],
+      [['1']],
+      [['-1']],
+      [['1.2']],
+      [['-1.2']],
+
+      // Valid values - nulls
+      [[null]],
+
+      // Valid values - objects
+      [[{}]],
+      [[{ a: 1 }]],
+      [[[]]],
+      [[[1]]],
+
+      // Valids values - mixed types
+      [['text', 10, false]],
+
+      // Value is not an array - should return ERROR_BAD_REQUEST
+      [null, [null]],
+      [false, [false]],
+      [true, [true]],
+      [0, [0]],
+      [1, [1]],
+      [-1, [-1]],
+      [1.2, [1.2]],
+      [-1.2, [-1.2]],
+      ['"text"', ['text']],
+      [{}, [{}]],
+    ]);
+  });
+};

--- a/test/rest-coercion/jsonbody-object.suite.js
+++ b/test/rest-coercion/jsonbody-object.suite.js
@@ -1,0 +1,73 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var jsonBodyContext = require('./_jsonbody.context');
+
+module.exports = function(ctx) {
+  ctx = jsonBodyContext(ctx);
+  var ERROR_BAD_REQUEST = ctx.ERROR_BAD_REQUEST;
+  var verifyTestCases = ctx.verifyTestCases;
+
+  describe('json body - object - required', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'anyname', type: 'object', required: true }, [
+      // Valid values, arrays are objects too
+      [[]], // an empty array is a valid value
+      [{}], // an empty object is a valid value too
+      [{ x: '' }],
+      [{ x: null }],
+      [[1, 2]],
+
+      // Invalid values trigger ERROR_BAD_REQUEST
+      [null, ERROR_BAD_REQUEST],
+    ]);
+  });
+
+  describe('json body - object - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'anyname', type: 'object' }, [
+      // Empty values
+      [null, ERROR_BAD_REQUEST], // should be: null
+
+      // Valid values, arrays are objects too
+      [[]],
+      [{}],
+
+      // Verify that deep coercion is not triggered
+      // and types specified in JSON are preserved
+
+      [{ x: '' }],
+      [{ x: null }],
+      [{ x: {}}],
+      [{ x: { key: null }}],
+      [{ x: 'value' }],
+      [{ x: 1 }],
+      [{ x: '1' }],
+      [{ x: -1 }],
+      [{ x: '-1' }],
+      [{ x: 1.2 }],
+      [{ x: '1.2' }],
+      [{ x: -1.2 }],
+      [{ x: '-1.2' }],
+      [{ x: ['text'] }],
+      [{ x: [1, 2] }],
+
+      // Numeric strings larger than MAX_SAFE_INTEGER
+      [{ x: '2343546576878989879789' }],
+      [{ x: '-2343546576878989879789' }],
+
+      // Strings mimicking scientific notation
+      [{ x: '1.234e+30' }],
+      [{ x: '-1.234e+30' }],
+
+      // Should we deep-coerce date values?
+      [{ x: '2016-05-19T13:28:51.299Z' }],
+      [{ x: '2016-05-19' }],
+      [{ x: 'Thu May 19 2016 15:28:51 GMT 0200 (CEST)' }],
+    ]);
+  });
+};

--- a/test/rest-coercion/jsonform-any.suite.js
+++ b/test/rest-coercion/jsonform-any.suite.js
@@ -1,0 +1,80 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var jsonFormContext = require('./_jsonform.context');
+
+module.exports = function(ctx) {
+  ctx = jsonFormContext(ctx);
+  var EMPTY_BODY = ctx.EMPTY_BODY;
+  var ERROR_BAD_REQUEST = ctx.ERROR_BAD_REQUEST;
+  var verifyTestCases = ctx.verifyTestCases;
+
+  describe('json form - any - required', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'any', required: true }, [
+      // Valid values
+      [{ arg: 1234 }, 1234],
+      [{ arg: 'text' }, 'text'],
+      [{ arg: 'undefined' }, 'undefined'],
+      // Invalid (empty) values should trigger ERROR_BAD_REQUEST
+      [EMPTY_BODY, ERROR_BAD_REQUEST],
+      [{ arg: '' }, ''],
+      [{ arg: null }, null],
+      [{ arg: 'null' }, null],
+    ]);
+  });
+
+  describe('json form - any - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'any' }, [
+      // Empty values
+      [EMPTY_BODY, undefined],
+      [{ arg: null }, null],
+      [{ arg: '' }, ''],
+
+      // Valid values
+      [{ arg: false }, false],
+      [{ arg: true }, true],
+      [{ arg: 0 }, 0],
+      [{ arg: 1 }, 1],
+      [{ arg: -1 }, -1],
+      [{ arg: 1.2 }, 1.2],
+      [{ arg: -1.2 }, -1.2],
+      [{ arg: 'text' }, 'text'],
+      [{ arg: [] }, []],
+      [{ arg: {}}, {}],
+
+      // Should `any` recognize date format?
+      [{ arg: '2016-05-19T13:28:51.299Z' }, '2016-05-19T13:28:51.299Z'],
+      [{ arg: '2016-05-19' }, '2016-05-19'],
+      [{ arg: 'Thu May 19 2016 15:28:51 GMT 0200 (CEST)' },
+        'Thu May 19 2016 15:28:51 GMT 0200 (CEST)'],
+
+      // Verify that deep coercion is not triggered
+      // and types specified in JSON are preserved
+      [{ arg: 'null' }, null], // should be string 'null'
+      [{ arg: 'false' }, false], // should be string 'false'
+      [{ arg: 'true' }, true], // should be string 'true'
+      [{ arg: '0' }, '0'],
+      [{ arg: '1' }, 1], // should be string '1'
+      [{ arg: '-1' }, '-1'],
+      [{ arg: '1.2' }, 1.2], // should be string '1.2'
+      [{ arg: '-1.2' }, '-1.2'], // should be -1.2 (number)
+      [{ arg: '[]' }, '[]'],
+      [{ arg: '{}' }, '{}'],
+
+      // Numberic strings larger than MAX_SAFE_INTEGER
+      // the following should be string '2343546576878989879789'
+      [{ arg: '2343546576878989879789' }, 2.34354657687899e+21],
+      [{ arg: '-2343546576878989879789' }, '-2343546576878989879789'],
+
+      // Strings mimicking scientific notation
+      [{ arg: '1.234e+30' }, '1.234e+30'],
+      [{ arg: '-1.234e+30' }, '-1.234e+30'],
+    ]);
+  });
+};

--- a/test/rest-coercion/jsonform-array.suite.js
+++ b/test/rest-coercion/jsonform-array.suite.js
@@ -1,0 +1,253 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var jsonFormContext = require('./_jsonform.context');
+
+var INVALID_DATE = new Date(NaN);
+
+module.exports = function(ctx) {
+  ctx = jsonFormContext(ctx);
+  var EMPTY_BODY = ctx.EMPTY_BODY;
+  var ERROR_BAD_REQUEST = ctx.ERROR_BAD_REQUEST;
+  var verifyTestCases = ctx.verifyTestCases;
+
+  describe('json form - array - required', function() {
+    // The exact type is not important to test how required array parameters
+    // treat missing values, therefore we test a single type (boolean) only.
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: ['boolean'], required: true }, [
+      // Valid values
+      [{ arg: [] }, []], // empty array is a valid value
+      [{ arg: [true, false] }, [true, false]],
+
+      // Empty values should trigger ERROR_BAD_REQUEST
+      [EMPTY_BODY, []],
+      [{ arg: null }, [false]],
+
+      // Invalid values  should trigger ERROR_BAD_REQUEST
+      [{ arg: [null] }, [false]],
+      [{ arg: false }, [false]],
+      [{ arg: true }, [true]],
+      [{ arg: 0 }, [false]],
+      [{ arg: 1 }, [true]],
+      [{ arg: '' }, []],
+      [{ arg: 'text' }, [true]],
+    ]);
+  });
+
+  describe('json form - array of booleans - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: ['boolean'] }, [
+      // Empty values
+      [EMPTY_BODY, []], // should be: undefined
+      [{ arg: [] }, []],
+      [{ arg: null }, [false]], // should be: null
+
+      // Valid values
+      [{ arg: [false] }, [false]],
+      [{ arg: [true] }, [true]],
+      [{ arg: [true, false] }, [true, false]],
+
+      // Value is not an array - should return ERROR_BAD_REQUEST
+      [{ arg: false }, [false]],
+      [{ arg: true }, [true]],
+      [{ arg: 0 }, [false]],
+      [{ arg: 1 }, [true]],
+      [{ arg: 2 }, [true]],
+      [{ arg: -1 }, [true]],
+      [{ arg: 'text' }, [true]],
+      [{ arg: {}}, [true]],
+
+      // Array items have wrong type - should return ERROR_BAD_REQUEST
+      [{ arg: [null] }, [false]],
+      [{ arg: ['true', 'false'] }, [true, false]],
+      [{ arg: ['0'] }, [false]],
+      [{ arg: ['1'] }, [true]],
+      [{ arg: ['2'] }, [true]],
+      [{ arg: ['-1'] }, [true]],
+      [{ arg: ['text'] }, [true]],
+      [{ arg: [{}] }, [true]],
+      [{ arg: [[]] }, [true]],
+    ]);
+  });
+
+  describe('json form - array of numbers - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: ['number'] }, [
+      // Empty values
+      [EMPTY_BODY, []], // should be: undefined
+      [{ arg: [] }, []],
+      [{ arg: null }, [0]], // should be: null
+
+      // Valid values
+      [{ arg: [0] }, [0]],
+      [{ arg: [1] }, [1]],
+      [{ arg: [-1] }, [-1]],
+      [{ arg: [0, 2, -2] }, [0, 2, -2]],
+      [{ arg: [1.2, -1.2] }, [1.2, -1.2]],
+      // Numbers larger than MAX_SAFE_INTEGER get trimmed
+      [{ arg: [2343546576878989879789] }, [2.34354657687899e+21]],
+      [{ arg: [-2343546576878989879789] }, [-2.34354657687899e+21]],
+      // Scientific notation
+      [{ arg: [1.234e+30] }, [1.234e+30]],
+      [{ arg: [-1.234e+30] }, [-1.234e+30]],
+
+      // Value is not an array - should return ERROR_BAD_REQUEST
+      [{ arg: false }, [0]],
+      [{ arg: true }, [1]],
+      [{ arg: 0 }, [0]],
+      [{ arg: '0' }, [0]],
+      [{ arg: 1 }, [1]],
+      [{ arg: '1' }, [1]],
+      [{ arg: -1 }, [-1]],
+      [{ arg: '-1' }, [-1]],
+      [{ arg: 1.2 }, [1.2]],
+      [{ arg: '1.2' }, [1.2]],
+      [{ arg: -1.2 }, [-1.2]],
+      [{ arg: '-1.2' }, [-1.2]],
+      [{ arg: 'text' }, ERROR_BAD_REQUEST],
+      [{ arg: {}}, ERROR_BAD_REQUEST],
+      [{ arg: { a: true }}, ERROR_BAD_REQUEST],
+
+      // Array items have wrong type - should return ERROR_BAD_REQUEST
+      [{ arg: [null] }, [0]],
+      [{ arg: ['0'] }, [0]],
+      [{ arg: ['1'] }, [1]],
+      [{ arg: ['-1'] }, [-1]],
+      [{ arg: ['1.2'] }, [1.2]],
+      [{ arg: ['-1.2'] }, [-1.2]],
+      [{ arg: ['text'] }, ERROR_BAD_REQUEST],
+      [{ arg: [1, 'text'] }, ERROR_BAD_REQUEST],
+    ]);
+  });
+
+  describe('json form - array of strings - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: ['string'] }, [
+      // Empty values
+      [EMPTY_BODY, []], // should be: undefined
+      [{ arg: [] }, []],
+      [{ arg: null }, ['null']], // should be: null
+
+      // Valid values
+      [{ arg: 'text' }, ['text']],
+      [{ arg: ['one', 'two'] }, ['one', 'two']],
+
+      // Value is not an array - should return ERROR_BAD_REQUEST
+      [{ arg: false }, ['false']],
+      [{ arg: true }, ['true']],
+      [{ arg: 0 }, ['0']],
+      [{ arg: 1 }, ['1']],
+      [{ arg: {}}, ['[object Object]']],
+
+      // Array items have wrong type - should return ERROR_BAD_REQUEST
+      [{ arg: [null] }, ['null']],
+      [{ arg: [0] }, ['0']],
+      [{ arg: [1] }, ['1']],
+      [{ arg: [true] }, ['true']],
+      [{ arg: [{}] }, ['[object Object]']],
+      [{ arg: [[]] }, ['']],
+    ]);
+  });
+
+  describe('json form - array of dates - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: ['date'] }, [
+      // Empty values
+      [EMPTY_BODY, []], // should be: undefined
+      [{ arg: [] }, []],
+      [{ arg: null }, [new Date(0)]], // should be: null
+
+      // Valid values - numbers are treated as timestamps
+      [{ arg: [0] }, [new Date(0)]],
+      [{ arg: [1] }, [new Date(1)]],
+
+      // Valid values - numeric strings are passed to Date.parse
+      [{ arg: ['0'] }, [new Date('0')]], // 1999-12-31T23:00:00.000Z in CEST
+      [{ arg: ['1'] }, [new Date('1')]], // 2000-12-31T23:00:00.000Z
+
+      // Valid values in ISO format
+      [{ arg: ['2016-05-19T13:28:51.299Z'] },
+        [new Date('2016-05-19T13:28:51.299Z')]],
+      [{ arg: ['2016-05-19T13:28:51.299Z', '2016-05-20T08:27:28.539Z'] }, [
+        new Date('2016-05-19T13:28:51.299Z'),
+        new Date('2016-05-20T08:27:28.539Z'),
+      ]],
+
+      // Value is not an array - should return ERROR_BAD_REQUEST
+      [{ arg: false }, [new Date(0)]],
+      [{ arg: true }, [new Date(1)]],
+      [{ arg: 'text' }, [INVALID_DATE]],
+      [{ arg: '2016-05-19T13:28:51.299Z' },
+        [new Date('2016-05-19T13:28:51.299Z')]],
+
+      // Array items have wrong type - should return ERROR_BAD_REQUEST
+      [{ arg: [null] }, [new Date(0)]],
+      [{ arg: ['text'] }, [INVALID_DATE]],
+    ]);
+  });
+
+  describe('json form - array of any - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: ['any'] }, [
+      // Empty values
+      [EMPTY_BODY, []], // should be: undefined
+      [{ arg: [] }, []],
+      [{ arg: null }, [null]], // should be: null
+
+      // Valid values - booleans
+      [{ arg: [true, false] }, [true, false]],
+
+      // Valid values - numbers
+      [{ arg: [0] }, [0]],
+      [{ arg: [1] }, [1]],
+      [{ arg: [-1] }, [-1]],
+      [{ arg: [0, 2, -2] }, [0, 2, -2]],
+      [{ arg: [1.2, -1.2] }, [1.2, -1.2]],
+
+      // Valid values - dates - should we coerce?
+      [{ arg: ['2016-05-19T13:28:51.299Z'] },
+        ['2016-05-19T13:28:51.299Z']],
+
+      // Valid values - strings
+      [{ arg: ['text'] }, ['text']],
+
+      // Boolean-like strings should not be coerced
+      [{ arg: ['true'] }, ['true']],
+
+      // Number-like strings should not be coerced
+      [{ arg: ['0'] }, ['0']],
+      [{ arg: ['1'] }, ['1']],
+      [{ arg: ['-1'] }, ['-1']],
+      [{ arg: ['1.2'] }, ['1.2']],
+      [{ arg: ['-1.2'] }, ['-1.2']],
+
+      // Valid values - nulls
+      [{ arg: [null] }, [null]],
+
+      // Valid values - objects
+      [{ arg: [{}] }, [{}]],
+      [{ arg: [{ a: 1 }] }, [{ a: 1 }]],
+      [{ arg: [[]] }, [[]]],
+      [{ arg: [[1]] }, [[1]]],
+
+      // Valids values - mixed types
+      [{ arg: ['text', 10, false] }, ['text', 10, false]],
+
+      // Value is not an array - should return ERROR_BAD_REQUEST
+      [{ arg: false }, [false]],
+      [{ arg: true }, [true]],
+      [{ arg: 0 }, [0]],
+      [{ arg: 1 }, [1]],
+      [{ arg: -1 }, [-1]],
+      [{ arg: 1.2 }, [1.2]],
+      [{ arg: -1.2 }, [-1.2]],
+      [{ arg: 'text' }, ['text']],
+      [{ arg: {}}, [{}]],
+    ]);
+  });
+};

--- a/test/rest-coercion/jsonform-boolean.suite.js
+++ b/test/rest-coercion/jsonform-boolean.suite.js
@@ -1,0 +1,57 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var jsonFormContext = require('./_jsonform.context');
+
+module.exports = function(ctx) {
+  ctx = jsonFormContext(ctx);
+  var EMPTY_BODY = ctx.EMPTY_BODY;
+  var ERROR_BAD_REQUEST = ctx.ERROR_BAD_REQUEST;
+  var verifyTestCases = ctx.verifyTestCases;
+
+  describe('json form - boolean - required', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'boolean', required: true }, [
+      // Valid values
+      [{ arg: false }, false],
+      [{ arg: true }, true],
+
+      // Empty values should trigger ERROR_BAD_REQUEST
+      [EMPTY_BODY, false],
+      [{ arg: null }, false],
+      [{ arg: '' }, false],
+    ]);
+  });
+
+  describe('json form - boolean - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'boolean' }, [
+      // Empty values
+      [EMPTY_BODY, false], // should be: undefined
+      [{ arg: null }, false], // should be: undefined or null
+
+      // Valid values
+      [{ arg: false }, false],
+      [{ arg: true }, true],
+
+      // Invalid values should trigger ERROR_BAD_REQUEST
+      [{ arg: '' }, false],
+      [{ arg: 'null' }, false],
+      [{ arg: 'false' }, false],
+      [{ arg: 'true' }, true],
+      [{ arg: 0 }, false],
+      [{ arg: '0' }, false],
+      [{ arg: 1 }, true],
+      [{ arg: '1' }, true],
+      [{ arg: 'text' }, true],
+      [{ arg: [] }, true],
+      [{ arg: [1, 2] }, true],
+      [{ arg: {}}, true],
+      [{ arg: { a: true }}, true],
+    ]);
+  });
+};

--- a/test/rest-coercion/jsonform-date.suite.js
+++ b/test/rest-coercion/jsonform-date.suite.js
@@ -1,0 +1,79 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var jsonFormContext = require('./_jsonform.context');
+
+var INVALID_DATE = new Date(NaN);
+
+module.exports = function(ctx) {
+  ctx = jsonFormContext(ctx);
+  var EMPTY_BODY = ctx.EMPTY_BODY;
+  var ERROR_BAD_REQUEST = ctx.ERROR_BAD_REQUEST;
+  var verifyTestCases = ctx.verifyTestCases;
+
+  describe('json form - date - required', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'date', required: true }, [
+      // Valid values
+      [{ arg: 0 }, new Date(0)],
+      [{ arg: '0' }, new Date('0')],
+      [{ arg: '2016-05-19T13:28:51.299Z' },
+        new Date('2016-05-19T13:28:51.299Z')],
+
+      // Empty values should trigger ERROR_BAD_REQUEST
+      [EMPTY_BODY, ERROR_BAD_REQUEST],
+      [{ arg: null }, new Date(0)], // should be: ERROR_BAD_REQUEST
+      [{ arg: '' }, INVALID_DATE], // should be: ERROR_BAD_REQUEST
+    ]);
+  });
+
+  describe('json form - date - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'date' }, [
+      // Empty cases
+      [EMPTY_BODY, undefined], // should be: undefined
+      [{ arg: null }, new Date(0)], // should be: null
+
+      // Valid values - ISO format
+      [{ arg: '2016-05-19T13:28:51.299Z' }, new Date('2016-05-19T13:28:51.299Z')],
+      [{ arg: '2016-05-19' }, new Date('2016-05-19')],
+      [{ arg: 'Thu May 19 2016 15:28:51 GMT 0200 (CEST)' },
+        new Date('2016-05-19T15:28:51.000Z')],
+
+      // Valid values - milliseconds from Unix Epoch
+      [{ arg: 0 }, new Date(0)],
+      [{ arg: 1 }, new Date(1)],
+      [{ arg: -1 }, new Date(-1)],
+      [{ arg: 1.2 }, new Date(1.2)],
+      [{ arg: -1.2 }, new Date(-1.2)],
+
+      // Valid values - numeric strings
+      [{ arg: '0' }, new Date('0')],
+      [{ arg: '1' }, new Date('1')],
+      [{ arg: '-1' }, new Date('-1')],
+      [{ arg: '1.2' }, new Date('1.2')],
+      [{ arg: '-1.2' }, new Date('-1.2')],
+
+      // Invalid values should trigger ERROR_BAD_REQUEST
+      [{ arg: '' }, INVALID_DATE], // should be: ERROR_BAD_REQUEST
+      [{ arg: 'null' }, INVALID_DATE], // should be: ERROR_BAD_REQUEST
+      [{ arg: false }, new Date(0)], // should be: ERROR_BAD_REQUEST
+      [{ arg: 'false' }, INVALID_DATE], // should be: ERROR_BAD_REQUEST
+      [{ arg: true }, new Date(1)], // should be: ERROR_BAD_REQUEST
+      [{ arg: 'true' }, INVALID_DATE], // should be: ERROR_BAD_REQUEST
+      [{ arg: 'text' }, INVALID_DATE], // should be: ERROR_BAD_REQUEST
+      [{ arg: [] }, INVALID_DATE], // should be: ERROR_BAD_REQUEST
+      [{ arg: {}}, INVALID_DATE], // should be: ERROR_BAD_REQUEST
+      // Numbers larger than MAX_SAFE_INTEGER - should cause ERROR_BAD_REQUEST
+      [{ arg: 2343546576878989879789 }, INVALID_DATE],
+      [{ arg: -2343546576878989879789 }, INVALID_DATE],
+      // Scientific notation - should cause ERROR_BAD_REQUEST
+      [{ arg: 1.234e+30 }, INVALID_DATE],
+      [{ arg: -1.234e+30 }, INVALID_DATE],
+    ]);
+  });
+};

--- a/test/rest-coercion/jsonform-number.suite.js
+++ b/test/rest-coercion/jsonform-number.suite.js
@@ -1,0 +1,77 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var jsonFormContext = require('./_jsonform.context');
+
+module.exports = function(ctx) {
+  ctx = jsonFormContext(ctx);
+  var EMPTY_BODY = ctx.EMPTY_BODY;
+  var ERROR_BAD_REQUEST = ctx.ERROR_BAD_REQUEST;
+  var verifyTestCases = ctx.verifyTestCases;
+
+  describe('json form - number - required', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'number', required: true }, [
+      // Valid values
+      [{ arg: 0 }, 0],
+      [{ arg: 1 }, 1],
+      [{ arg: -1 }, -1],
+
+      // Empty values should trigger ERROR_BAD_REQUEST
+      [EMPTY_BODY, ERROR_BAD_REQUEST],
+      [{ arg: null }, 0], // should be: ERROR_BAD_REQUEST
+      [{ arg: '' }, 0], // should be: ERROR_BAD_REQUEST
+    ]);
+  });
+
+  describe('json form - number - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'number' }, [
+      // Empty values
+      [EMPTY_BODY, undefined],
+      [{ arg: null }, 0], // should be: null
+
+      // Valid values
+      [{ arg: 0 }, 0],
+      [{ arg: 1 }, 1],
+      [{ arg: -1 }, -1],
+      [{ arg: 1.2 }, 1.2],
+      [{ arg: -1.2 }, -1.2],
+
+      // Numbers larger than MAX_SAFE_INTEGER get trimmed
+      [{ arg: 2343546576878989879789 }, 2.34354657687899e+21],
+      [{ arg: -2343546576878989879789 }, -2.34354657687899e+21],
+
+      // Scientific notation works
+      [{ arg: 1.234e+30 }, 1.234e+30],
+      [{ arg: -1.234e+30 }, -1.234e+30],
+
+      // Number-like string values should trigger ERROR_BAD_REQUEST
+      [{ arg: '0' }, 0],
+      [{ arg: '1' }, 1],
+      [{ arg: '-1' }, -1],
+      [{ arg: '1.2' }, 1.2],
+      [{ arg: '-1.2' }, -1.2],
+      [{ arg: '2343546576878989879789' }, 2.34354657687899e+21],
+      [{ arg: '-2343546576878989879789' }, -2.34354657687899e+21],
+      [{ arg: '1.234e+30' }, 1.234e+30],
+      [{ arg: '-1.234e+30' }, -1.234e+30],
+
+      // All other non-number values should trigger ERROR_BAD_REQUEST
+      [{ arg: '' }, 0],
+      [{ arg: false }, 0],
+      [{ arg: 'false' }, ERROR_BAD_REQUEST],
+      [{ arg: true }, 1],
+      [{ arg: 'true' }, ERROR_BAD_REQUEST],
+      [{ arg: 'text' }, ERROR_BAD_REQUEST],
+      [{ arg: [] }, 0],
+      [{ arg: [1, 2] }, ERROR_BAD_REQUEST],
+      [{ arg: {}}, ERROR_BAD_REQUEST],
+      [{ arg: { a: true }}, ERROR_BAD_REQUEST],
+    ]);
+  });
+};

--- a/test/rest-coercion/jsonform-object.suite.js
+++ b/test/rest-coercion/jsonform-object.suite.js
@@ -1,0 +1,72 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var jsonFormContext = require('./_jsonform.context');
+
+module.exports = function(ctx) {
+  ctx = jsonFormContext(ctx);
+  var EMPTY_BODY = ctx.EMPTY_BODY;
+  var ERROR_BAD_REQUEST = ctx.ERROR_BAD_REQUEST;
+  var verifyTestCases = ctx.verifyTestCases;
+
+  describe('json form - object - required', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'object', required: true }, [
+      // Valid values
+      [{ arg: {}}, {}],
+      [{ arg: { foo: 'bar' }}, { foo: 'bar' }],
+      // Arrays are objects too
+      [{ arg: [] }, []],
+      [{ arg: [1, 2] }, [1, 2]],
+
+      // Empty values should trigger ERROR_BAD_REQUEST
+      [EMPTY_BODY, ERROR_BAD_REQUEST],
+      [{ arg: null }, ERROR_BAD_REQUEST],
+      [{ arg: '' }, ERROR_BAD_REQUEST],
+    ]);
+  });
+
+  describe('json form - object - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'object' }, [
+      // Empty values
+      [EMPTY_BODY, undefined],
+      [{ arg: null }, ERROR_BAD_REQUEST], // should be null
+
+      // Valid values
+      [{ arg: { x: null }}, { x: null }],
+      [{ arg: {}}, {}],
+      [{ arg: { x: 'value' }}, { x: 'value' }],
+      [{ arg: { x: 1 }}, { x: 1 }],
+
+      // Arrays are objects too
+      [{ arg: [] }, []],
+      [{ arg: ['text'] }, ['text']],
+      [{ arg: [1, 2] }, [1, 2]],
+
+      // Verify that deep coercion is not triggered
+      // and types specified in JSON are preserved
+      [{ arg: { x: '1' }}, { x: '1' }],
+      [{ arg: { x: -1 }}, { x: -1 }],
+      [{ arg: { x: '-1' }}, { x: '-1' }],
+      [{ arg: { x: 1.2 }}, { x: 1.2 }],
+      [{ arg: { x: '1.2' }}, { x: '1.2' }],
+      [{ arg: { x: -1.2 }}, { x: -1.2 }],
+      [{ arg: { x: '-1.2' }}, { x: '-1.2' }],
+      [{ arg: { x: 'true' }}, { x: 'true' }],
+      [{ arg: { x: 'false' }}, { x: 'false' }],
+
+      // Invalid values should trigger ERROR_BAD_REQUEST
+      [{ arg: '' }, ERROR_BAD_REQUEST],
+      [{ arg: false }, ERROR_BAD_REQUEST],
+      [{ arg: true }, ERROR_BAD_REQUEST],
+      [{ arg: 0 }, ERROR_BAD_REQUEST],
+      [{ arg: 1 }, ERROR_BAD_REQUEST],
+      [{ arg: -1 }, ERROR_BAD_REQUEST],
+    ]);
+  });
+};

--- a/test/rest-coercion/jsonform-string.suite.js
+++ b/test/rest-coercion/jsonform-string.suite.js
@@ -1,0 +1,65 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var jsonFormContext = require('./_jsonform.context');
+
+module.exports = function(ctx) {
+  ctx = jsonFormContext(ctx);
+  var EMPTY_BODY = ctx.EMPTY_BODY;
+  var ERROR_BAD_REQUEST = ctx.ERROR_BAD_REQUEST;
+  var verifyTestCases = ctx.verifyTestCases;
+
+  describe('json form - string - required', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'string', required: true }, [
+      // Valid values
+      [{ arg: 'null' }, 'null'],
+      [{ arg: 'text' }, 'text'],
+
+      // Empty values should trigger ERROR_BAD_REQUEST
+      [EMPTY_BODY, ERROR_BAD_REQUEST],
+      [{ arg: '' }, ''],
+      [{ arg: null }, 'null'],
+    ]);
+  });
+
+  describe('json form - string - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'string' }, [
+      // Empty values
+      [EMPTY_BODY, undefined],
+      [{ arg: '' }, ''],
+      [{ arg: null }, 'null'], // should be: null
+
+      // Valid values
+      [{ arg: 'text' }, 'text'],
+
+      // Verify that deep coercion is not triggered
+      // and types specified in JSON are preserved
+      [{ arg: 'undefined' }, 'undefined'],
+      [{ arg: 'null' }, 'null'],
+      [{ arg: '0' }, '0'],
+      [{ arg: '1' }, '1'],
+      [{ arg: '-1' }, '-1'],
+      [{ arg: '1.2' }, '1.2'],
+      [{ arg: '-1.2' }, '-1.2'],
+      [{ arg: 'false' }, 'false'],
+      [{ arg: 'true' }, 'true'],
+
+      // Invalid values should trigger ERROR_BAD_REQUEST
+      [{ arg: false }, 'false'],
+      [{ arg: true }, 'true'],
+      [{ arg: 0 }, '0'],
+      [{ arg: 1 }, '1'],
+      [{ arg: -1 }, '-1'],
+      [{ arg: 1.2 }, '1.2'],
+      [{ arg: -1.2 }, '-1.2'],
+      [{ arg: [] }, ''],
+      [{ arg: {}}, '[object Object]'],
+    ]);
+  });
+};

--- a/test/rest-coercion/urlencoded-any.suite.js
+++ b/test/rest-coercion/urlencoded-any.suite.js
@@ -1,0 +1,75 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var urlEncodedContext = require('./_urlencoded.context');
+
+module.exports = function(ctx) {
+  suite('query string', urlEncodedContext(ctx, 'qs'));
+  suite('form data', urlEncodedContext(ctx, 'form'));
+};
+
+function suite(prefix, ctx) {
+  var EMPTY_QUERY = ctx.EMPTY_QUERY;
+  var ERROR_BAD_REQUEST = ctx.ERROR_BAD_REQUEST;
+  var verifyTestCases = ctx.verifyTestCases;
+
+  describe(prefix + ' - any - required', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'any', required: true }, [
+      // Valid values
+      ['arg=1234', 1234],
+      ['arg=text', 'text'],
+
+      // Empty values should trigger ERROR_BAD_REQUEST
+      [EMPTY_QUERY, ERROR_BAD_REQUEST],
+      ['arg', ''], // should be: ERROR_BAD_REQUEST
+      ['arg=', ''], // should be: ERROR_BAD_REQUEST
+      ['arg=null', null], // should be: ERROR_BAD_REQUEST
+    ]);
+  });
+
+  describe(prefix + ' - any - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'any' }, [
+      // Empty values
+      [EMPTY_QUERY, undefined],
+      ['arg', ''], // should be: undefined
+      ['arg=', ''], // should be: undefined
+      ['arg=null', null], // should be: 'null'
+
+      // Valid values (coerced)
+      ['arg=undefined', 'undefined'], // 'undefined' is treated as a string
+      ['arg=false', false],
+      ['arg=true', true],
+      ['arg=0', '0'], // should be 0 (number)
+      ['arg=1', 1],
+      ['arg=-1', '-1'], // should be -1 (number)
+      ['arg=1.2', 1.2],
+      ['arg=-1.2', '-1.2'], // should be -1.2 (number)
+      ['arg=text', 'text'],
+      ['arg=[]', '[]'], // should be an empty array
+      ['arg={}', '{}'], // should be an empty object
+      ['arg={x:1}', '{x:1}'], // should be parsed as an object {x:1}
+      ['arg={x:"1"}', '{x:"1"}'], // should be parsed as an object {x:'1'}
+      ['arg=[1]', '[1]'], // should be parsed as an array [1]
+      ['arg=["1"]', '["1"]'], // should be parsed as an array ['1']
+
+      // Numbers larger than MAX_SAFE_INTEGER
+      ['arg=2343546576878989879789', 2.34354657687899e+21],
+      // This should have been recognized as number
+      ['arg=-2343546576878989879789', '-2343546576878989879789'],
+      // Scientific notation should be recognized as a number
+      ['arg=1.234e%2B30', '1.234e+30'],
+      ['arg=-1.234e%2B30', '-1.234e+30'],
+      // Should `any` recognize date format?
+      ['arg=2016-05-19T13:28:51.299Z', '2016-05-19T13:28:51.299Z'],
+      ['arg=2016-05-19', '2016-05-19'],
+      ['arg=Thu+May+19+2016+15:28:51+GMT+0200+(CEST)',
+        'Thu May 19 2016 15:28:51 GMT 0200 (CEST)'],
+    ]);
+  });
+};

--- a/test/rest-coercion/urlencoded-array.suite.js
+++ b/test/rest-coercion/urlencoded-array.suite.js
@@ -1,0 +1,263 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var urlEncodedContext = require('./_urlencoded.context');
+
+var INVALID_DATE = new Date(NaN);
+
+module.exports = function(ctx) {
+  suite('query string', urlEncodedContext(ctx, 'qs'));
+  suite('form data', urlEncodedContext(ctx, 'form'));
+};
+
+function suite(prefix, ctx) {
+  var EMPTY_QUERY = ctx.EMPTY_QUERY;
+  var ERROR_BAD_REQUEST = ctx.ERROR_BAD_REQUEST;
+  var verifyTestCases = ctx.verifyTestCases;
+
+  describe(prefix + ' - array - required', function() {
+    // The exact type is not important to test how required array parameters
+    // treat missing values, therefore we test a single type (boolean) only.
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: ['boolean'], required: true }, [
+      // Valid values - JSON encoding
+      ['arg=[]', []],
+      ['arg=[true,false]', [true, false]],
+
+      // Valid values - nested keys
+      ['arg=false', [false]],
+      ['arg=true', [true]],
+      ['arg=true&arg=false', [true, false]],
+
+      // Empty values should trigger ERROR_BAD_REQUEST
+      [EMPTY_QUERY, []], // should be: ERROR_BAD_REQUEST
+      ['arg', []], // should be: ERROR_BAD_REQUEST
+      ['arg=', []], // should be: ERROR_BAD_REQUEST
+
+      // Invalid values - array items have wrong type or value is not an array
+      // All test cases should trigger ERROR_BAD_REQUEST
+      ['arg=null', [false]],
+      ['arg=undefined', [false]],
+      ['arg=0', [false]],
+      ['arg=1', [true]],
+      ['arg={}', [true]],
+      ['arg=["true"]', [true]],
+      ['arg=[1]', [true]],
+    ]);
+  });
+
+  describe(prefix + ' - array of booleans - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: ['boolean'] }, [
+      // Empty values
+      [EMPTY_QUERY, []], // should be: undefined
+      ['arg', []], // should be: undefined
+      ['arg=', []], // should be: undefined
+      ['arg=null', [false]], // should be: null
+
+      // Valid values - repeated keys
+      ['arg=false', [false]],
+      ['arg=true', [true]],
+      ['arg=true&arg=false', [true, false]],
+
+      // Valid values - JSON encoding
+      ['arg=[]', []],
+      ['arg=[true,false]', [true, false]],
+
+      // Invalid values should trigger ERROR_BAD_REQUEST
+      ['arg=undefined', [false]],
+      ['arg=true&arg=text', [true, true]],
+      ['arg=0', [false]],
+      ['arg=1', [true]],
+      ['arg=2', [true]],
+      ['arg=-1', [true]],
+      ['arg=text', [true]],
+      ['arg=[1,2]', [true, true]],
+      ['arg=["text"]', [true]],
+      ['arg=[null]', [false]],
+      ['arg={}', [true]],
+      ['arg={"a":true}', [true]],
+
+      // Malformed JSON should trigger ERROR_BAD_REQUEST
+      ['arg={malformed}', [true]],
+      ['arg=[malformed]', [true]],
+    ]);
+  });
+
+  describe(prefix + ' - array of numbers - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: ['number'] }, [
+      // Empty values
+      [EMPTY_QUERY, []], // should be: undefined
+      ['arg', []], // should be: undefined
+      ['arg=', []], // should be: undefined
+
+      // Valid values - repeated keys
+      ['arg=0', [0]],
+      ['arg=1', [1]],
+      ['arg=-1', [-1]],
+      ['arg=1.2', [1.2]],
+      ['arg=-1.2', [-1.2]],
+      ['arg=1&arg=2', [1, 2]],
+      // Numbers larger than MAX_SAFE_INTEGER get trimmed
+      ['arg=2343546576878989879789', [2.34354657687899e+21]],
+      ['arg=-2343546576878989879789', [-2.34354657687899e+21]],
+      // Scientific notation
+      ['arg=1.234e%2B30', [1.234e+30]],
+      ['arg=-1.234e%2B30', [-1.234e+30]],
+
+      // Valid values - JSON encoding
+      ['arg=[]', []],
+      ['arg=[1,2]', [1, 2]],
+
+      // Invalid values should trigger ERROR_BAD_REQUEST
+      ['arg=undefined', ERROR_BAD_REQUEST],
+      ['arg=null', ERROR_BAD_REQUEST],
+      ['arg=true', ERROR_BAD_REQUEST],
+      ['arg=false', ERROR_BAD_REQUEST],
+      ['arg=text', ERROR_BAD_REQUEST],
+      ['arg=1&arg=text', ERROR_BAD_REQUEST],
+      ['arg=["1"]', [1]], // notice the item is a string, we should not coerce
+      ['arg=[1,"text"]', ERROR_BAD_REQUEST],
+      ['arg=[null]', [0]],
+      ['arg={}', ERROR_BAD_REQUEST],
+      ['arg={"a":true}', ERROR_BAD_REQUEST],
+
+      // Malformed JSON should trigger ERROR_BAD_REQUEST
+      ['arg={malformed}', ERROR_BAD_REQUEST],
+      ['arg=[malformed]', ERROR_BAD_REQUEST],
+    ]);
+  });
+
+  describe(prefix + ' - array of strings - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: ['string'] }, [
+      // Empty values
+      [EMPTY_QUERY, []], // should be: undefined
+      ['arg', []], // should be: undefined
+      ['arg=', []], // should be: undefined
+
+      // Valid values - repeated keys
+      ['arg=undefined', ['undefined']],
+      ['arg=null', ['null']],
+      ['arg=0', ['0']],
+      ['arg=1', ['1']],
+      ['arg=false', ['false']],
+      ['arg=true', ['true']],
+      ['arg=-1', ['-1']],
+      ['arg=1.2', ['1.2']],
+      ['arg=-1.2', ['-1.2']],
+      ['arg=text', ['text']],
+      ['arg=one&arg=two', ['one', 'two']],
+
+      // Valid values - JSON encoding
+      ['arg=[]', []],
+      ['arg=[1,2]', ['1', '2']],
+
+      // Invalid values should trigger ERROR_BAD_REQUEST
+      ['arg={}', ['{}']],
+      ['arg={"a":true}', ['{"a":true}']],
+      ['arg=[1]', ['1']],
+      ['arg=[true]', ['true']],
+      ['arg=[null]', ['null']],
+
+      // Malformed JSON should trigger ERROR_BAD_REQUEST
+      ['arg={malformed}', ['{malformed}']],
+      ['arg=[malformed]', ['[malformed]']],
+    ]);
+  });
+
+  describe(prefix + ' - array of dates - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: ['date'] }, [
+      // Empty values
+      [EMPTY_QUERY, []], // should be: undefined
+      ['arg', []], // should be: undefined
+      ['arg=', []], // should be: undefined
+
+      // Valid values - repeated keys
+      ['arg=0', [new Date('0')]], // 1999-12-31T23:00:00.000Z in CEST
+      ['arg=1', [new Date('1')]], // 2000-12-31T23:00:00.000Z
+      ['arg=text', [INVALID_DATE]], // should be: ERROR_BAD_REQUEST
+      ['arg=2016-05-19T13:28:51.299Z',
+        [new Date('2016-05-19T13:28:51.299Z')]],
+      ['arg=2016-05-19T13:28:51.299Z&arg=2016-05-20T08:27:28.539Z', [
+        new Date('2016-05-19T13:28:51.299Z'),
+        new Date('2016-05-20T08:27:28.539Z'),
+      ]],
+
+      // Valid values - JSON encoding
+      ['arg=[]', []],
+      ['arg=[0]', [new Date(0)]],
+      ['arg=[1]', [new Date(1)]],
+      ['arg=[-1]', [new Date(-1)]],
+      ['arg=["2016-05-19T13:28:51.299Z"]',
+        [new Date('2016-05-19T13:28:51.299Z')]],
+      ['arg=["2016-05-19T13:28:51.299Z", "2016-05-20T08:27:28.539Z"]', [
+        new Date('2016-05-19T13:28:51.299Z'),
+        new Date('2016-05-20T08:27:28.539Z'),
+      ]],
+
+      // Invalid values should trigger ERROR_BAD_REQUEST
+      ['arg=undefined', [INVALID_DATE]], // should be: ERROR_BAD_REQUEST
+      ['arg=null', [INVALID_DATE]], // should be: ERROR_BAD_REQUEST
+      ['arg=false', [INVALID_DATE]], // should be: ERROR_BAD_REQUEST
+      ['arg=true', [INVALID_DATE]], // should be: ERROR_BAD_REQUEST
+      ['arg={}', [INVALID_DATE]], // should be: ERROR_BAD_REQUEST
+      ['arg={"a":true}', [INVALID_DATE]],
+      ['arg=[null]', [new Date(0)]],
+      ['arg=[false]', [new Date(0)]],
+      ['arg=[true]', [new Date(1)]],
+      ['arg=["text"]', [INVALID_DATE]],
+
+      // Malformed JSON should trigger ERROR_BAD_REQUEST
+      ['arg={malformed}', [INVALID_DATE]], // should be: ERROR_BAD_REQUEST
+      ['arg=[malformed]', [INVALID_DATE]], // should be: ERROR_BAD_REQUEST
+    ]);
+  });
+
+  describe(prefix + ' - array of any - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: ['any'] }, [
+      // Empty values
+      [EMPTY_QUERY, []], // should be: undefined
+      ['arg', []], // should be: undefined
+      ['arg=', []], // should be: undefined
+      ['arg=null', [null]], // should be: null (?)
+
+      // Valid values - repeated keys
+      ['arg=undefined', ['undefined']],
+      ['arg=false', [false]],
+      ['arg=true', [true]],
+      ['arg=0', ['0']], // should be 0 (number)
+      ['arg=1', [1]],
+      ['arg=-1', ['-1']], // should be -1 (number)
+      ['arg=1.2', [1.2]],
+      ['arg=-1.2', ['-1.2']], // should be -1.2 (number)
+      ['arg=text', ['text']],
+      ['arg=text&arg=10&arg=false', ['text', '10', 'false']], // should be coerced
+      // Numbers larger than MAX_SAFE_INTEGER
+      ['arg=2343546576878989879789', [2.34354657687899e+21]],
+      // this should have been recognized as number
+      ['arg=-2343546576878989879789', ['-2343546576878989879789']],
+      // Scientific notation - should it be recognized as a number?
+      ['arg=1.234e%2B30&arg=-1.234e%2B30', ['1.234e+30', '-1.234e+30']],
+
+      // Valid values - JSON encoding
+      ['arg=[]', []],
+      ['arg=["text",10,false]', ['text', 10, false]],
+
+      // Invalid values should trigger ERROR_BAD_REQUEST
+      ['arg={}', ['{}']],
+      ['arg={"foo":"bar"}', ['{"foo":"bar"}']],
+
+      // Malformed JSON should trigger ERROR_BAD_REQUEST
+      ['arg={malformed}', ['{malformed}']],
+      ['arg=[malformed]', ['[malformed]']],
+    ]);
+  });
+};

--- a/test/rest-coercion/urlencoded-boolean.suite.js
+++ b/test/rest-coercion/urlencoded-boolean.suite.js
@@ -1,0 +1,68 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var urlEncodedContext = require('./_urlencoded.context');
+
+module.exports = function(ctx) {
+  suite('query string', urlEncodedContext(ctx, 'qs'));
+  suite('form data', urlEncodedContext(ctx, 'form'));
+};
+
+function suite(prefix, ctx) {
+  var EMPTY_QUERY = ctx.EMPTY_QUERY;
+  var ERROR_BAD_REQUEST = ctx.ERROR_BAD_REQUEST;
+  var verifyTestCases = ctx.verifyTestCases;
+
+  describe(prefix + ' - boolean - required', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'boolean', required: true }, [
+      // Valid values
+      ['arg=false', false],
+      ['arg=true', true],
+
+      // Empty values should trigger ERROR_BAD_REQUEST
+      [EMPTY_QUERY, false],
+      ['arg', false],
+      ['arg=', false],
+
+      // Empty-like values should trigger ERROR_BAD_REQUEST too
+      ['arg=undefined', false],
+      ['arg=null', false],
+      ['arg=0', false],
+    ]);
+  });
+
+  describe(prefix + ' - boolean - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'boolean' }, [
+      // Empty values
+      [EMPTY_QUERY, false], // should be: undefined
+      ['arg', false], // should be: undefined
+      ['arg=', false], // should be: undefined
+
+      // Valid values
+      ['arg=false', false],
+      ['arg=true', true],
+      // values are case insensitive
+      ['arg=FalsE', true], // should be false
+      ['arg=TruE', true],
+      ['arg=FALSE', true], // should be false
+      ['arg=TRUE', true],
+
+      // Invalid values should trigger ERROR_BAD_REQUEST
+      ['arg=undefined', false],
+      ['arg=null', false],
+      ['arg=0', false],
+      ['arg=1', true],
+      ['arg=text', true],
+      ['arg=[]', true],
+      ['arg=[1,2]', true],
+      ['arg={}', true],
+      ['arg={"a":true}', true],
+    ]);
+  });
+};

--- a/test/rest-coercion/urlencoded-date.suite.js
+++ b/test/rest-coercion/urlencoded-date.suite.js
@@ -1,0 +1,84 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var urlEncodedContext = require('./_urlencoded.context');
+
+var INVALID_DATE = new Date(NaN);
+
+module.exports = function(ctx) {
+  suite('query string', urlEncodedContext(ctx, 'qs'));
+  suite('form data', urlEncodedContext(ctx, 'form'));
+};
+
+function suite(prefix, ctx) {
+  var EMPTY_QUERY = ctx.EMPTY_QUERY;
+  var ERROR_BAD_REQUEST = ctx.ERROR_BAD_REQUEST;
+  var verifyTestCases = ctx.verifyTestCases;
+
+  describe(prefix + ' - date - required', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'date', required: true }, [
+      // Valid values
+      ['arg=2016-05-19T13:28:51.299Z', new Date('2016-05-19T13:28:51.299Z')],
+
+      // Empty values should trigger ERROR_BAD_REQUEST
+      [EMPTY_QUERY, ERROR_BAD_REQUEST],
+      ['arg', INVALID_DATE],
+      ['arg=', INVALID_DATE],
+
+      // Empty-like values should trigger ERROR_BAD_REQUEST too
+      ['arg=undefined', INVALID_DATE],
+      ['arg=null', INVALID_DATE],
+    ]);
+  });
+
+  describe(prefix + ' - date - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'date' }, [
+      // Empty values
+      [EMPTY_QUERY, undefined],
+      ['arg', INVALID_DATE], // should be: undefined
+      ['arg=', INVALID_DATE], // should be: undefined
+
+      // Valid values - ISO format
+      ['arg=2016-05-19T13:28:51.299Z', new Date('2016-05-19T13:28:51.299Z')],
+      ['arg=2016-05-19', new Date('2016-05-19')],
+      ['arg=Thu+May+19+2016+15:28:51+GMT+0200+(CEST)',
+        new Date('2016-05-19T15:28:51.000Z')],
+
+      // NOTE(bajtos) should we convert the numeric values into a number
+      // before passing it to the Date constructor?
+      // That way ?arg=0 would produce '1970-01-01T00:00:00.000Z', which is
+      // arguably more expected then some date around 1999/2000/2001
+      // Also note that with the current implementation, the parsed
+      // value depends on the timezone of the server, therefore
+      // we cannot specify exact date values here in the test
+      // and have to use the same Date input as in the HTTP request :(
+      // See also https://github.com/strongloop/strong-remoting/issues/238
+      ['arg=0', new Date('0')], // 1999-12-31T23:00:00.000Z in CEST
+      ['arg=1', new Date('1')], // 2000-12-31T23:00:00.000Z
+      ['arg=-1', new Date('-1')], // 2000-12-31T23:00:00.000Z
+      ['arg=1.2', new Date('1.2')], // 2001-01-01T23:00:00.000Z
+      ['arg=-1.2', new Date('-1.2')], // 2001-01-01T23:00:00.000Z
+
+      // Invalid values should trigger ERROR_BAD_REQUEST
+      ['arg=undefined', INVALID_DATE],
+      ['arg=null', INVALID_DATE],
+      ['arg=false', INVALID_DATE],
+      ['arg=true', INVALID_DATE],
+      ['arg=text', INVALID_DATE],
+      ['arg=[]', INVALID_DATE],
+      ['arg={}', INVALID_DATE],
+      // Numbers larger than MAX_SAFE_INTEGER - should cause ERROR_BAD_REQUEST
+      ['arg=2343546576878989879789', INVALID_DATE],
+      ['arg=-2343546576878989879789', INVALID_DATE],
+      // Scientific notation - should cause ERROR_BAD_REQUEST
+      ['arg=1.234e%2B30', INVALID_DATE],
+      ['arg=-1.234e%2B30', INVALID_DATE],
+    ]);
+  });
+};

--- a/test/rest-coercion/urlencoded-number.suite.js
+++ b/test/rest-coercion/urlencoded-number.suite.js
@@ -1,0 +1,72 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var urlEncodedContext = require('./_urlencoded.context');
+
+module.exports = function(ctx) {
+  suite('query string', urlEncodedContext(ctx, 'qs'));
+  suite('form data', urlEncodedContext(ctx, 'form'));
+};
+
+function suite(prefix, ctx) {
+  var EMPTY_QUERY = ctx.EMPTY_QUERY;
+  var ERROR_BAD_REQUEST = ctx.ERROR_BAD_REQUEST;
+  var verifyTestCases = ctx.verifyTestCases;
+
+  describe(prefix + ' - number - required', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'number', required: true }, [
+      // Valid values
+      ['arg=0', 0],
+      ['arg=1', 1],
+      ['arg=-1', -1],
+
+      // Empty values should trigger ERROR_BAD_REQUEST
+      [EMPTY_QUERY, ERROR_BAD_REQUEST],
+      ['arg', 0],
+      ['arg=', 0],
+
+      // Empty-like values should trigger ERROR_BAD_REQUEST too
+      ['arg=undefined', ERROR_BAD_REQUEST],
+      ['arg=null', ERROR_BAD_REQUEST],
+    ]);
+  });
+
+  describe(prefix + ' - number - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'number' }, [
+      // Empty values
+      [EMPTY_QUERY, undefined],
+      ['arg', 0], // should be: undefined
+      ['arg=', 0], // should be: undefined
+
+      // Valid values
+      ['arg=0', 0],
+      ['arg=1', 1],
+      ['arg=-1', -1],
+      ['arg=1.2', 1.2],
+      ['arg=-1.2', -1.2],
+      // Numbers larger than MAX_SAFE_INTEGER get trimmed
+      ['arg=2343546576878989879789', 2.34354657687899e+21],
+      ['arg=-2343546576878989879789', -2.34354657687899e+21],
+      // Scientific notation
+      ['arg=1.234e%2B30', 1.234e+30],
+      ['arg=-1.234e%2B30', -1.234e+30],
+
+      // Invalid values should trigger ERROR_BAD_REQUEST
+      ['arg=undefined', ERROR_BAD_REQUEST],
+      ['arg=null', ERROR_BAD_REQUEST],
+      ['arg=true', ERROR_BAD_REQUEST],
+      ['arg=false', ERROR_BAD_REQUEST],
+      ['arg=text', ERROR_BAD_REQUEST],
+      ['arg=[]', ERROR_BAD_REQUEST],
+      ['arg=[1,2]', ERROR_BAD_REQUEST],
+      ['arg={}', ERROR_BAD_REQUEST],
+      ['arg={"a":true}', ERROR_BAD_REQUEST],
+    ]);
+  });
+};

--- a/test/rest-coercion/urlencoded-object.suite.js
+++ b/test/rest-coercion/urlencoded-object.suite.js
@@ -1,0 +1,121 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var urlEncodedContext = require('./_urlencoded.context');
+
+module.exports = function(ctx) {
+  suite('query string', urlEncodedContext(ctx, 'qs'));
+  suite('form data', urlEncodedContext(ctx, 'form'));
+};
+
+function suite(prefix, ctx) {
+  var EMPTY_QUERY = ctx.EMPTY_QUERY;
+  var ERROR_BAD_REQUEST = ctx.ERROR_BAD_REQUEST;
+  var verifyTestCases = ctx.verifyTestCases;
+
+  describe(prefix + ' - object - required', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'object', required: true }, [
+      // Valid values - JSON encoding
+      ['arg={}', {}],
+      ['arg={"foo":"bar"}', { foo: 'bar' }],
+      // arrays are objects too
+      ['arg=[]', []],
+      ['arg=[1,2]', [1, 2]],
+
+      // Valid values - nested keys
+      ['arg[key]=undefined', { key: 'undefined' }],
+      ['arg[key]=null', { key: 'null' }],
+      ['arg[key]=text', { key: 'text' }],
+
+      // Empty values should trigger ERROR_BAD_REQUEST
+      [EMPTY_QUERY, ERROR_BAD_REQUEST],
+      ['arg', ERROR_BAD_REQUEST],
+      ['arg=', ERROR_BAD_REQUEST],
+      // Empty-like values should trigger ERROR_BAD_REQUEST too
+      ['arg=null', ERROR_BAD_REQUEST],
+      ['arg=undefined', ERROR_BAD_REQUEST],
+    ]);
+  });
+
+  describe(prefix + ' - object - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'object' }, [
+      // Empty values
+      [EMPTY_QUERY, undefined], // should be: undefined
+      ['arg', ERROR_BAD_REQUEST], // should be undefined
+      ['arg=', ERROR_BAD_REQUEST], // should be undefined
+      ['arg=null', ERROR_BAD_REQUEST], // should be null
+      ['arg={}', {}],
+      ['arg=[]', []],
+
+      // Valid values - nested keys
+      // Nested values are NOT coerced (no deep coercion)
+      ['arg[key]=undefined', { key: 'undefined' }],
+      ['arg[key]=null', { key: 'null' }],
+      ['arg[key]=value', { key: 'value' }],
+      ['arg[key]=0', { key: '0' }],
+      ['arg[key]=1', { key: '1' }],
+      ['arg[key]=-1', { key: '-1' }],
+      ['arg[key]=1.2', { key: '1.2' }],
+      ['arg[key]=-1.2', { key: '-1.2' }],
+      ['arg[key]=true', { key: 'true' }],
+      ['arg[key]=false', { key: 'false' }],
+      ['arg[x]=a&arg[y]=b', { x: 'a', y: 'b' }],
+      ['arg[key]=[1,2]', { key: '[1,2]' }],
+      ['arg[key]=1&arg[key]=2', { key: ['1', '2'] }],
+      // Numbers larger than MAX_SAFE_INTEGER are kept as strings
+      ['arg[key]=2343546576878989879789', { key: '2343546576878989879789' }],
+      ['arg[key]=-2343546576878989879789', { key: '-2343546576878989879789' }],
+      // Scientific notation is not parsed
+      ['arg[key]=1.234e%2B30', { key: '1.234e+30' }],
+      ['arg[key]=-1.234e%2B30', { key: '-1.234e+30' }],
+      // Dates are preserved in string
+      ['arg[key]=2016-05-19T13:28:51.299Z',
+        { key: '2016-05-19T13:28:51.299Z' }],
+      ['arg[a]=2016-05-19T13:28:51.299Z&arg[b]=2016-05-20T08:27:28.539Z', {
+        a: '2016-05-19T13:28:51.299Z',
+        b: '2016-05-20T08:27:28.539Z',
+      }],
+
+      // Valid values - JSON encoding
+      ['arg={"key":null}', { key: null }],
+      ['arg={"key":"value"}', { key: 'value' }],
+      ['arg={"key":false}', { key: false }],
+      ['arg={"key":true}', { key: true }],
+      ['arg={"key":0}', { key: 0 }],
+      ['arg={"key":1}', { key: 1 }],
+      ['arg={"key":-1}', { key: -1 }],
+      ['arg={"key":1.2}', { key: 1.2 }],
+      ['arg={"key":-1.2}', { key: -1.2 }],
+      ['arg=["text"]', ['text']],
+      // Nested values are NOT coerced (no deep coercion)
+      ['arg={"key":"false"}', { key: 'false' }],
+      ['arg={"key":"true"}', { key: 'true' }],
+      ['arg={"key":"0"}', { key: '0' }],
+      ['arg={"key":"1"}', { key: '1' }],
+      ['arg={"key":"-1"}', { key: '-1' }],
+      ['arg={"key":"1.2"}', { key: '1.2' }],
+      ['arg={"key":"-1.2"}', { key: '-1.2' }],
+
+      // arrays are objects too
+      ['arg=[1,2]', [1, 2]],
+      ['arg=[1,"text"]', [1, 'text']],
+
+      // Invalid values should trigger ERROR_BAD_REQUEST
+      ['arg=undefined', ERROR_BAD_REQUEST],
+      ['arg=false', ERROR_BAD_REQUEST],
+      ['arg=true', ERROR_BAD_REQUEST],
+      ['arg=0', ERROR_BAD_REQUEST],
+      ['arg=1', ERROR_BAD_REQUEST],
+      ['arg=-1', ERROR_BAD_REQUEST],
+      ['arg=text', ERROR_BAD_REQUEST],
+      ['arg={malformed}', ERROR_BAD_REQUEST],
+      ['arg=[malformed]', ERROR_BAD_REQUEST],
+    ]);
+  });
+};

--- a/test/rest-coercion/urlencoded-string.suite.js
+++ b/test/rest-coercion/urlencoded-string.suite.js
@@ -1,0 +1,67 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var urlEncodedContext = require('./_urlencoded.context');
+
+module.exports = function(ctx) {
+  suite('query string', urlEncodedContext(ctx, 'qs'));
+  suite('form data', urlEncodedContext(ctx, 'form'));
+};
+
+function suite(prefix, ctx) {
+  var EMPTY_QUERY = ctx.EMPTY_QUERY;
+  var ERROR_BAD_REQUEST = ctx.ERROR_BAD_REQUEST;
+  var verifyTestCases = ctx.verifyTestCases;
+
+  describe(prefix + ' - string - required', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'string', required: true }, [
+      // Valid values
+      ['arg=text', 'text'],
+      // Empty-like values are treated as strings
+      ['arg=undefined', 'undefined'],
+      ['arg=null', 'null'],
+
+      // Empty values should trigger ERROR_BAD_REQUEST
+      [EMPTY_QUERY, ERROR_BAD_REQUEST],
+      ['arg', ''],
+      ['arg=', ''],
+    ]);
+  });
+
+  describe(prefix + ' - string - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'string' }, [
+      // Empty values
+      [EMPTY_QUERY, undefined],
+      ['arg', ''], // should be: undefined
+      ['arg=', ''],
+
+      // Valid values - all non-empty value are valid strings
+      ['arg=undefined', 'undefined'],
+      ['arg=null', 'null'],
+      ['arg=0', '0'],
+      ['arg=1', '1'],
+      ['arg=false', 'false'],
+      ['arg=true', 'true'],
+      ['arg=-1', '-1'],
+      ['arg=1.2', '1.2'],
+      ['arg=-1.2', '-1.2'],
+      ['arg=text', 'text'],
+      ['arg=[]', '[]'],
+      ['arg=[1,2]', '[1,2]'],
+      ['arg={}', '{}'],
+      ['arg={"a":true}', '{"a":true}'],
+      // Numbers larger than MAX_SAFE_INTEGER are preserved in string
+      ['arg=2343546576878989879789', '2343546576878989879789'],
+      ['arg=-2343546576878989879789', '-2343546576878989879789'],
+      // Scientific notation
+      ['arg=1.234e%2B30', '1.234e+30'],
+      ['arg=-1.234e%2B30', '-1.234e+30'],
+    ]);
+  });
+};


### PR DESCRIPTION
An integration test suite describing and verifying argument coercion in REST.
 - [x] arguments in query string
 - [x]  arguments in JSON body (formdata)
 - [x] arguments in url-encoded formdata
 - [x] the JSON body as an argument

```
1230 passing (3s)
```

(see https://github.com/strongloop-internal/scrum-loopback/issues/706#issuecomment-217371058 for more information)

In this pull request, I am describing the current behaviour in the `master` branch. My intention is to run the test suite against different strong-remoting versions to find differences, I'll post results later.

> In order to discover all breaking changes and document the new behaviour, we should write an extensive integration test suite that can be run against different versions of strong-remoting. Here is an initial draft for inspiration: https://gist.github.com/bajtos/b85e53a79ba06671e08d2013acccc611 Versions to run the suite against: v2.16.0, v2.16.1, latest 2.x, master (3.0-alpha). This commit may have introduced breaking change in v2.16.1: strongloop/strong-remoting@34b0665

Connect to strongloop-internal/scrum-loopback#884
Connect to strongloop-internal/scrum-loopback#913

@ritch @STRML please take a look