### PR TITLE
Implement getEndpoints

### DIFF
--- a/lib/http-invocation.js
+++ b/lib/http-invocation.js
@@ -163,7 +163,8 @@ HttpInvocation.prototype._processArg = function(req, verb, query, accept) {
 
 HttpInvocation.prototype.createRequest = function() {
   var method = this.method;
-  var verb = method.getHttpMethod();
+  var endpoint = method.getEndpoints()[0];
+  var verb = endpoint.verb;
   var req = this.req = { method: verb || 'GET' };
   var accepts = method.accepts;
   var ctorAccepts = null;
@@ -171,7 +172,7 @@ HttpInvocation.prototype.createRequest = function() {
   var auth = this.auth;
 
   // initial url is the format
-  req.url = this.base + method.getFullPath();
+  req.url = this.base + endpoint.fullPath;
 
   var parsedUrl = urlUtil.parse(req.url);
 

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -16,6 +16,7 @@ RestAdapter.RestMethod = RestMethod;
  * Module dependencies.
  */
 
+var deprecated = require('depd')('strong-remoting');
 var EventEmitter = require('events').EventEmitter;
 var debug = require('debug')('strong-remoting:rest-adapter');
 var util = require('util');
@@ -619,11 +620,30 @@ RestMethod.prototype.acceptsSingleBodyArgument = function() {
     getTypeString(accepts.type) == 'object' || false;
 };
 
+RestMethod.prototype.getEndpoints = function() {
+  var self = this;
+  return this.routes.map(function(route) {
+    var verbResult;
+    var verb = route.verb;
+    if (verb == 'all') {
+      verbResult = 'POST';
+    } else if (verb == 'del') {
+      verbResult = 'DELETE';
+    } else {
+      verbResult = verb.toUpperCase();
+    }
+    return {
+      verb: verbResult,
+      fullPath: joinPaths(self.restClass.getPath(), route.path),
+    };
+  });
+};
+
 RestMethod.prototype.getHttpMethod = function() {
-  var verb = this.routes[0].verb;
-  if (verb == 'all') return 'POST';
-  if (verb == 'del') return 'DELETE';
-  return verb.toUpperCase();
+  // deprecate message to let the users know what they were using
+  // was retuning just the first route's verb
+  deprecated('getHttpMethod() is deprecated, use getEndpoints()[0].verb instead.');
+  return this.getEndpoints()[0].verb;
 };
 
 RestMethod.prototype.getPath = function() {
@@ -631,7 +651,10 @@ RestMethod.prototype.getPath = function() {
 };
 
 RestMethod.prototype.getFullPath = function() {
-  return joinPaths(this.restClass.getPath(), this.getPath());
+  // deprecate message to let the users know what they were using
+  // was retuning just the first route's path
+  deprecated('getFullPath() is deprecated, use getEndpoints()[0].fullPath instead.');
+  return this.getEndpoints()[0].fullPath;
 };
 
 function getTypeString(ctorOrName) {

--- a/test/rest-adapter.test.js
+++ b/test/rest-adapter.test.js
@@ -13,6 +13,7 @@ var SharedClass = require('../lib/shared-class');
 var SharedMethod = require('../lib/shared-method');
 var expect = require('chai').expect;
 var factory = require('./helpers/shared-objects-factory.js');
+function NOOP() {};
 
 describe('RestAdapter', function() {
   var remotes;
@@ -218,6 +219,8 @@ describe('RestAdapter', function() {
     });
 
     describe('getHttpMethod', function() {
+      ignoreDeprecationsInThisBlock();
+
       it('returns POST for `all`', function() {
         var method = givenRestStaticMethod({ http: { verb: 'all' }});
         expect(method.getHttpMethod()).to.equal('POST');
@@ -245,6 +248,8 @@ describe('RestAdapter', function() {
     });
 
     describe('getFullPath', function() {
+      ignoreDeprecationsInThisBlock();
+
       it('returns class path + method path', function() {
         var method = givenRestStaticMethod(
           { http: { path: '/a-method' }},
@@ -252,6 +257,37 @@ describe('RestAdapter', function() {
         );
 
         expect(method.getFullPath()).to.equal('/a-class/a-method');
+      });
+    });
+
+    describe('getEndpoints', function() {
+      it('should return verb and fullPath for multiple paths', function() {
+        var method = givenRestStaticMethod({ http: [
+          { verb: 'DEL', path: '/testMethod1' },
+          { verb: 'PUT', path: '/testMethod2' },
+        ] });
+
+        var expectedEndpoints = [
+          {
+            fullPath: '/testClass/testMethod1',
+            verb: 'DELETE',
+          }, {
+            fullPath: '/testClass/testMethod2',
+            verb: 'PUT',
+          },
+        ];
+
+        expect(method.getEndpoints()).to.eql(expectedEndpoints);
+      });
+
+      it('should return verb and fullPath for single path', function() {
+        var method = givenRestStaticMethod({ http: { verb: 'all' }});
+        expect(method.getEndpoints()).to.eql([
+          {
+            verb: 'POST',
+            fullPath: '/testClass/testMethod',
+          },
+        ]);
       });
     });
 
@@ -438,4 +474,14 @@ describe('RestAdapter', function() {
 });
 
 function someFunc() {
+}
+
+function ignoreDeprecationsInThisBlock() {
+  before(function() {
+    process.on('deprecation', NOOP);
+  });
+
+  after(function() {
+    process.removeListener('deprecation', NOOP);
+  });
 }


### PR DESCRIPTION
This patch includes:

* Implement `getEndpoints` which returns an array of objects, showing verbs and paths
* Deprecate `getHttpMethod`
* Deprecate `getFullPath`

/to: @bajtos 