### PR TITLE
Move sharedCtor call after auth checks

### DIFF
--- a/lib/remote-objects.js
+++ b/lib/remote-objects.js
@@ -642,6 +642,18 @@ RemoteObjects.prototype._setupPhases = function() {
     self._executeAuthorizationHook(ctx, next);
   });
 
+  invoke.before(function buildInstance(ctx, next) {
+    var sharedMethod = ctx.method;
+    if (sharedMethod.isStatic)
+      return next();
+
+    ctx.invoke(sharedMethod.ctor, sharedMethod.sharedCtor, function(err, inst) {
+      if (err) return next(err);
+      ctx.instance = inst;
+      next();
+    }, true);
+  });
+
   invoke.before(function phaseBeforeInvoke(ctx, next) {
     self.execHooks('before', ctx.method, ctx.getScope(), ctx, next);
   });

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -417,9 +417,12 @@ RestAdapter.errorHandler = function(options) {
 RestAdapter.prototype._registerMethodRouteHandlers = function(router,
                                                               sharedMethod,
                                                               route) {
-  var handler = sharedMethod.isStatic ?
-    this._createStaticMethodHandler(sharedMethod) :
-    this._createPrototypeMethodHandler(sharedMethod);
+  var self = this;
+  var Context = this.Context;
+  var handler = function restMethodHandler(req, res, next) {
+    var ctx = new Context(req, res, sharedMethod, self.options);
+    self._invokeMethod(ctx, sharedMethod, next);
+  };
 
   debug('        %s %s %s', route.verb, route.path, handler.name);
   var verb = route.verb;
@@ -430,32 +433,6 @@ RestAdapter.prototype._registerMethodRouteHandlers = function(router,
   router[verb](route.path, handler);
 };
 
-RestAdapter.prototype._createStaticMethodHandler = function(sharedMethod) {
-  var self = this;
-  var Context = this.Context;
-
-  return function restStaticMethodHandler(req, res, next) {
-    var ctx = new Context(req, res, sharedMethod, self.options);
-    self._invokeMethod(ctx, sharedMethod, next);
-  };
-};
-
-RestAdapter.prototype._createPrototypeMethodHandler = function(sharedMethod) {
-  var self = this;
-  var Context = this.Context;
-
-  return function restPrototypeMethodHandler(req, res, next) {
-    var ctx = new Context(req, res, sharedMethod, self.options);
-
-    // invoke the shared constructor to get an instance
-    ctx.invoke(sharedMethod.ctor, sharedMethod.sharedCtor, function(err, inst) {
-      if (err) return next(err);
-      ctx.instance = inst;
-      self._invokeMethod(ctx, sharedMethod, next);
-    }, true);
-  };
-};
-
 RestAdapter.prototype._invokeMethod = function(ctx, method, next) {
   var remotes = this.remotes;
   var steps = [];
@@ -463,6 +440,7 @@ RestAdapter.prototype._invokeMethod = function(ctx, method, next) {
   if (method.rest.before) {
     steps.push(function invokeRestBefore(cb) {
       debug('Invoking rest.before for ' + ctx.methodString);
+      // NOTE: scope is always Model ctor, never the instance
       method.rest.before.call(ctx.getScope(), ctx, cb);
     });
   }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "karma-script-launcher": "~0.1.0",
     "mocha": "~2.2.5",
     "requirejs": "~2.1.17",
+    "sinon": "^1.17.4",
     "socket.io": "~1.3.5",
     "supertest": "~1.0.1"
   },

--- a/test/helpers/shared-objects-factory.js
+++ b/test/helpers/shared-objects-factory.js
@@ -36,15 +36,21 @@ exports.createSharedClass =  function createSharedClass(config) {
   SharedClass.shared = true;
 
   SharedClass.sharedCtor = function(id, cb) {
-    cb(null, new SharedClass(id));
+    // allow tests to override the implementation of shared ctor
+    // while preserving remoting metadata
+    this._sharedCtor(id, cb);
   };
 
   extend(SharedClass.sharedCtor, {
     shared: true,
     accepts: [{ arg: 'id', type: 'any', http: { source: 'path' }}],
     http: { path: '/:id' },
-    returns: { root: true }
+    returns: { arg: 'instance', type: 'object', root: true }
   });
+
+  SharedClass._sharedCtor = function(id, cb) {
+    cb(null, new SharedClass(id));
+  };
 
   return SharedClass;
 };

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -2042,6 +2042,25 @@ describe('strong-remoting-rest', function() {
       });
     });
 
+    it('should prioritise auth errors over sharedCtor errors', function(done) {
+      var method = givenSharedPrototypeMethod();
+      method.ctor._sharedCtor = function(ctx, next) {
+        var err = new Error('Not Found');
+        err.statusCode = 404;
+        next(err);
+      };
+
+      objects.authorization = function(ctx, next) {
+        var err = new Error('Not Authorized');
+        err.statusCode = 401;
+        next(err);
+      };
+
+      json(method.getUrlForId('instId'))
+        // Verify that we return 401 Not Authorized and hide 404 Not Found
+        .expect(401, done);
+    });
+
     it('should not call sharedCtor when not authenticated', function(done) {
       var sharedCtorCalled = false;
 


### PR DESCRIPTION
Possible breaking change (only prototype methods are affected):

Any code run before "invoke:before" phase (where we initialise the
instance) will not receive `ctx.instance`:

 - "remotes.authorization" hook
 - "rest.before" hooks
 - custom phases inserted before "invoke" phase

Connect to #311

@ritch please review ASAP.