### PR TITLE
Prioritise auth errors over sharedCtor errors

### DIFF
--- a/lib/remote-objects.js
+++ b/lib/remote-objects.js
@@ -642,6 +642,10 @@ RemoteObjects.prototype._setupPhases = function() {
     self._executeAuthorizationHook(ctx, next);
   });
 
+  invoke.before(function reportSharedCtorError(ctx, next) {
+    next(ctx.sharedCtorError);
+  });
+
   invoke.before(function phaseBeforeInvoke(ctx, next) {
     self.execHooks('before', ctx.method, ctx.getScope(), ctx, next);
   });

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -449,8 +449,15 @@ RestAdapter.prototype._createPrototypeMethodHandler = function(sharedMethod) {
 
     // invoke the shared constructor to get an instance
     ctx.invoke(sharedMethod.ctor, sharedMethod.sharedCtor, function(err, inst) {
-      if (err) return next(err);
-      ctx.instance = inst;
+      if (err) {
+        // Defer handling of this error until the request is authorized.
+        // The error handler is in RemotObjects.prototype._setupPhase
+        // TODO(bajtos) refactor this code so that sharedCtor is invoked
+        // from "invokeMethodInContext" too, see #315
+        ctx.sharedCtorError = err;
+      } else {
+        ctx.instance = inst;
+      }
       self._invokeMethod(ctx, sharedMethod, next);
     }, true);
   };

--- a/test/helpers/shared-objects-factory.js
+++ b/test/helpers/shared-objects-factory.js
@@ -36,15 +36,21 @@ exports.createSharedClass =  function createSharedClass(config) {
   SharedClass.shared = true;
 
   SharedClass.sharedCtor = function(id, cb) {
-    cb(null, new SharedClass(id));
+    // allow tests to override the implementation of shared ctor
+    // while preserving remoting metadata
+    this._sharedCtor(id, cb);
   };
 
   extend(SharedClass.sharedCtor, {
     shared: true,
     accepts: [{ arg: 'id', type: 'any', http: { source: 'path' }}],
     http: { path: '/:id' },
-    returns: { root: true }
+    returns: { arg: 'instance', type: 'object', root: true }
   });
+
+  SharedClass._sharedCtor = function(id, cb) {
+    cb(null, new SharedClass(id));
+  };
 
   return SharedClass;
 };

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -2040,6 +2040,25 @@ describe('strong-remoting-rest', function() {
         done();
       });
     });
+
+    it('should prioritise auth errors over sharedCtor errors', function(done) {
+      var method = givenSharedPrototypeMethod();
+      method.ctor._sharedCtor = function(ctx, next) {
+        var err = new Error('Not Found');
+        err.statusCode = 404;
+        next(err);
+      };
+
+      objects.authorization = function(ctx, next) {
+        var err = new Error('Not Authorized');
+        err.statusCode = 401;
+        next(err);
+      };
+
+      json(method.getUrlForId('instId'))
+        // Verify that we return 401 Not Authorized and hide 404 Not Found
+        .expect(401, done);
+    });
   });
 
   describe('status codes', function() {


### PR DESCRIPTION
Return 401 Not Authorized when making an unauthorised request to a prototype method for a model instance that does not exist.

Potentially breaking change affecting prototype methods:

Hooks registered before "invoke" phase (i.e. "auth" phase and any custom
phases inserted before "invoke") will be called even when the model
instance was not found. The property "ctx.instance" will be undefined
in such case, hook handlers must account for this case.

This is an alternative to #315 that may have less breaking changes.

Connect to #311

@ritch please review.