### PR TITLE
Introduce support for integer datatype

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -285,6 +285,12 @@ function badArgumentError(msg) {
   return err;
 }
 
+function internalServerError(msg) {
+  var err = new Error(msg);
+  err.statusCode = 500;
+  return err;
+}
+
 function escapeRegex(d) {
   // see http://stackoverflow.com/a/6969486/69868
   return d.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
@@ -318,7 +324,7 @@ function coerceAccepts(uarg, desc) {
     });
   }
 
-  var actualType = SharedMethod.getType(uarg);
+  var actualType = SharedMethod.getType(uarg, targetType);
 
   // convert values to the correct type
   // TODO(bajtos) Move conversions to HttpContext (and friends)
@@ -331,7 +337,7 @@ function coerceAccepts(uarg, desc) {
     // JSON.parse can throw, so catch this error.
     try {
       uarg = convertValueToTargetType(name, uarg, targetType);
-      actualType = SharedMethod.getType(uarg);
+      actualType = SharedMethod.getType(uarg, targetType);
     } catch (e) {
       var message = util.format('invalid value for argument \'%s\' of type ' +
         '\'%s\': %s. Received type was %s. Error: %s',
@@ -369,7 +375,14 @@ function coerceAccepts(uarg, desc) {
   if (actualType === 'number' && Number.isNaN(uarg)) {
     throw new badArgumentError(name + ' must be a number');
   }
-
+  if (actualType === 'integer') {
+    if (Number.isNaN(uarg)) {
+      throw new badArgumentError(name + ' must be an integer');
+    }
+    if (!Number.isSafeInteger(uarg)) {
+      throw new badArgumentError(name + ' must be a safe integer');
+    }
+  }
   return uarg;
 }
 
@@ -395,6 +408,7 @@ function convertToBasicRemotingType(type) {
   switch (type) {
     case 'string':
     case 'number':
+    case 'integer':
     case 'date':
     case 'boolean':
     case 'buffer':
@@ -417,6 +431,7 @@ function convertValueToTargetType(argName, value, targetType) {
     case 'date':
       return new Date(value);
     case 'number':
+    case 'integer':
       return Number(value).valueOf();
     case 'boolean':
       return Boolean(value).valueOf();
@@ -440,16 +455,18 @@ function convertValueToTargetType(argName, value, targetType) {
  * @returns {String} The type name
  */
 
-SharedMethod.getType = function(val) {
+SharedMethod.getType = function(val, targetType) {
   var type = typeof val;
 
   switch (type) {
     case 'undefined':
     case 'boolean':
-    case 'number':
     case 'function':
     case 'string':
       return type;
+    case 'number':
+      return Number.isInteger(val) && targetType === 'integer' ?
+        'integer' : 'number';
     case 'object':
       // null
       if (val === null) {
@@ -541,8 +558,9 @@ SharedMethod.toResult = function(returns, raw, ctx) {
     }
 
     if (item.root) {
-      var isFile = convertToBasicRemotingType(item.type) === 'file';
-      result = isFile ? raw[index] : convert(raw[index]);
+      var targetType = convertToBasicRemotingType(item.type);
+      var isFile =  targetType === 'file';
+      result = isFile ? raw[index] : convert(raw[index], targetType, item.name);
       return false;
     }
 
@@ -551,21 +569,34 @@ SharedMethod.toResult = function(returns, raw, ctx) {
 
   returns.forEach(function(item, index) {
     var name = item.name || item.arg;
-    if (convertToBasicRemotingType(item.type) === 'file') {
+    var targetType = convertToBasicRemotingType(item.type);
+    if (targetType === 'file') {
       console.warn('%s: discarded non-root return argument %s of type "file"',
         this.stringName,
         name);
       return;
     }
 
-    var value = convert(raw[index]);
+    var value = convert(raw[index], targetType, name);
     result[name] = value;
   });
 
   return result;
 
-  function convert(val) {
-    switch (SharedMethod.getType(val)) {
+  function convert(val, targetType, argName) {
+    var targetTypeIsIntegerArray = Array.isArray(targetType) &&
+      targetType.length === 1 && targetType[0] === 'integer';
+
+    if (targetTypeIsIntegerArray && Array.isArray(val)) {
+      var arrayTargetType = targetType[0];
+      return val.map(function(intVal) {
+        return convert(intVal, arrayTargetType, argName);
+      });
+    }
+
+    var actualType = SharedMethod.getType(val, targetType);
+
+    switch (actualType) {
       case 'date':
         return {
           $type: 'date',
@@ -576,9 +607,29 @@ SharedMethod.toResult = function(returns, raw, ctx) {
           $type: 'base64',
           $data: val.toString('base64'),
         };
-    }
+      default:
+        if (targetType === 'integer') {
+          var message;
 
-    return val;
+          if (!Number.isInteger(val)) {
+            message = util.format(
+              'Invalid return value for argument \'%s\' of type ' +
+              '\'%s\': %s. Received type was %s.',
+              argName, targetType, val, typeof val);
+            throw internalServerError(message);
+          }
+
+          if (!Number.isSafeInteger(val)) {
+            message = util.format(
+              'Unsafe integer value returned for argument \'%s\' of type ' +
+              '\'%s\': %s.',
+              argName, targetType, val);
+            throw internalServerError(message);
+          }
+          return val;
+        }
+        return val;
+    }
   }
 };
 
@@ -664,4 +715,17 @@ SharedMethod.prototype.addAlias = function(alias) {
   if (this.aliases.indexOf(alias) === -1) {
     this.aliases.push(alias);
   }
+};
+
+// To support Node v.0.10.x
+Number.isInteger = Number.isInteger || function(value) {
+  return typeof value === 'number' &&
+    isFinite(value) &&
+    Math.floor(value) === value;
+};
+
+Number.MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER || Math.pow(2, 53) - 1;
+
+Number.isSafeInteger = Number.isSafeInteger || function(value) {
+  return Number.isInteger(value) && Math.abs(value) <= Number.MAX_SAFE_INTEGER;
 };

--- a/test/rest-coercion/jsonform-integer.suite.js
+++ b/test/rest-coercion/jsonform-integer.suite.js
@@ -1,0 +1,79 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var jsonFormContext = require('./_jsonform.context');
+
+module.exports = function(ctx) {
+  ctx = jsonFormContext(ctx);
+  var EMPTY_BODY = ctx.EMPTY_BODY;
+  var ERROR_BAD_REQUEST = ctx.ERROR_BAD_REQUEST;
+  var verifyTestCases = ctx.verifyTestCases;
+
+  describe('json form - integer - required', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'integer', required: true }, [
+      // Valid values
+      [{ arg: 0 }, 0],
+      [{ arg: 1 }, 1],
+      [{ arg: -1 }, -1],
+
+      // Empty values should trigger ERROR_BAD_REQUEST
+      [EMPTY_BODY, ERROR_BAD_REQUEST],
+      [{ arg: null }, 0], // should be: ERROR_BAD_REQUEST
+      [{ arg: '' }, 0], // should be: ERROR_BAD_REQUEST
+    ]);
+  });
+
+  describe('json form - integer - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'integer' }, [
+      // Empty values
+      [EMPTY_BODY, undefined],
+      [{ arg: null }, 0], // should be: null
+
+      // Valid values
+      [{ arg: 0 }, 0],
+      [{ arg: 1 }, 1],
+      [{ arg: -1 }, -1],
+
+      // Integers larger than MAX_SAFE_INTEGER should trigger ERROR_BAD_REQUEST
+      [{ arg: 2343546576878989879789 }, ERROR_BAD_REQUEST],
+      [{ arg: -2343546576878989879789 }, ERROR_BAD_REQUEST],
+
+      // Scientific notation works
+      [{ arg: 1.234e+3 }, 1.234e+3],
+      [{ arg: -1.234e+3 }, -1.234e+3],
+
+      // Integer-like string values should trigger ERROR_BAD_REQUEST
+      [{ arg: '0' }, 0],
+      [{ arg: '1' }, 1],
+      [{ arg: '-1' }, -1],
+      [{ arg: '2343546576878989879789' }, ERROR_BAD_REQUEST],
+      [{ arg: '-2343546576878989879789' }, ERROR_BAD_REQUEST],
+      [{ arg: '1.234e+30' }, ERROR_BAD_REQUEST],
+      [{ arg: '-1.234e+30' }, ERROR_BAD_REQUEST],
+      [{ arg: '1.234e+3' }, 1.234e+3],
+      [{ arg: '-1.234e+3' }, -1.234e+3],
+
+      // All other non-integer values should trigger ERROR_BAD_REQUEST
+      [{ arg: 1.2 }, ERROR_BAD_REQUEST],
+      [{ arg: -1.2 }, ERROR_BAD_REQUEST],
+      [{ arg: '1.2' }, ERROR_BAD_REQUEST],
+      [{ arg: '-1.2' }, ERROR_BAD_REQUEST],
+      [{ arg: '' }, 0],
+      [{ arg: false }, 0],
+      [{ arg: 'false' }, ERROR_BAD_REQUEST],
+      [{ arg: true }, 1],
+      [{ arg: 'true' }, ERROR_BAD_REQUEST],
+      [{ arg: 'text' }, ERROR_BAD_REQUEST],
+      [{ arg: [] }, 0],
+      [{ arg: [1, 2] }, ERROR_BAD_REQUEST],
+      [{ arg: {}}, ERROR_BAD_REQUEST],
+      [{ arg: { a: true }}, ERROR_BAD_REQUEST],
+    ]);
+  });
+};

--- a/test/rest-coercion/urlencoded-integer.suite.js
+++ b/test/rest-coercion/urlencoded-integer.suite.js
@@ -1,0 +1,73 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var urlEncodedContext = require('./_urlencoded.context');
+
+module.exports = function(ctx) {
+  suite('query string', urlEncodedContext(ctx, 'qs'));
+  suite('form data', urlEncodedContext(ctx, 'form'));
+};
+
+function suite(prefix, ctx) {
+  var EMPTY_QUERY = ctx.EMPTY_QUERY;
+  var ERROR_BAD_REQUEST = ctx.ERROR_BAD_REQUEST;
+  var verifyTestCases = ctx.verifyTestCases;
+
+  describe(prefix + ' - integer - required', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'integer', required: true }, [
+      // Valid values
+      ['arg=0', 0],
+      ['arg=1', 1],
+      ['arg=-1', -1],
+
+      // Empty values should trigger ERROR_BAD_REQUEST
+      [EMPTY_QUERY, ERROR_BAD_REQUEST],
+      ['arg', 0],
+      ['arg=', 0],
+
+      // Empty-like values should trigger ERROR_BAD_REQUEST too
+      ['arg=undefined', ERROR_BAD_REQUEST],
+      ['arg=null', ERROR_BAD_REQUEST],
+    ]);
+  });
+
+  describe(prefix + ' - integer - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'integer' }, [
+      // Empty values
+      [EMPTY_QUERY, undefined],
+      ['arg', 0], // should be: undefined
+      ['arg=', 0], // should be: undefined
+
+      // Valid values
+      ['arg=0', 0],
+      ['arg=1', 1],
+      ['arg=-1', -1],
+
+      // Numbers larger than MAX_SAFE_INTEGER should trigger ERROR_BAD_REQUEST
+      ['arg=2343546576878989879789', ERROR_BAD_REQUEST],
+      ['arg=-2343546576878989879789', ERROR_BAD_REQUEST],
+      // Scientific notation
+      ['arg=1.234e%2B3', 1.234e+3],
+      ['arg=-1.234e%2B3', -1.234e+3],
+
+      // Invalid values should trigger ERROR_BAD_REQUEST
+      ['arg=1.2', ERROR_BAD_REQUEST],
+      ['arg=-1.2', ERROR_BAD_REQUEST],
+      ['arg=undefined', ERROR_BAD_REQUEST],
+      ['arg=null', ERROR_BAD_REQUEST],
+      ['arg=true', ERROR_BAD_REQUEST],
+      ['arg=false', ERROR_BAD_REQUEST],
+      ['arg=text', ERROR_BAD_REQUEST],
+      ['arg=[]', ERROR_BAD_REQUEST],
+      ['arg=[1,2]', ERROR_BAD_REQUEST],
+      ['arg={}', ERROR_BAD_REQUEST],
+      ['arg={"a":true}', ERROR_BAD_REQUEST],
+    ]);
+  });
+}

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -950,28 +950,65 @@ describe('strong-remoting-rest', function() {
           done();
         });
     });
+    describe('data type - integer', function() {
+      it('should coerce integer strings', function(done) {
+        remotes.foo = {
+          bar: function(a, b, fn) {
+            fn(null, a + b);
+          },
+        };
 
-    it('should coerce contents of array with simple array types', function(done) {
-      remotes.foo = {
-        bar: function(a, fn) {
-          fn(null, a.reduce(function(memo, val) { return memo + val; }, 0));
-        },
-      };
+        var fn = remotes.foo.bar;
 
-      var fn = remotes.foo.bar;
+        fn.shared = true;
+        fn.accepts = [
+          { arg: 'a', type: 'integer' },
+          { arg: 'b', type: 'integer' },
+        ];
+        fn.returns = { root: true };
 
-      fn.shared = true;
-      fn.accepts = [
-        { arg: 'a', type: ['number'] },
-      ];
-      fn.returns = { root: true };
+        json('get', '/foo/bar?a=53&b=2')
+          .expect(200, function(err, res) {
+            assert.equal(res.body, 55);
+            done();
+          });
+      });
 
-      json('get', '/foo/bar?a=["1","2","3","4","5"]')
-        .expect(200, function(err, res) {
-          assert.equal(res.body, 15);
-          done();
-        });
+      it('supports target type [integer]', function(done) {
+        var method = givenSharedStaticMethod(
+          function(arg, cb) {
+            cb(null, { value: arg });
+          },
+          {
+            accepts: { arg: 'arg', type: ['integer'] },
+            returns: { arg: 'data', type: ['integer'], root: true },
+            http: { method: 'POST' },
+          });
+
+        request(app).post(method.url)
+          .send({ arg: [1, 2] })
+          .expect(200, { value: [1, 2] })
+          .end(done);
+      });
+
+      it('supports return type [integer]', function(done) {
+        var method = givenSharedStaticMethod(
+          function(arg, cb) {
+            cb(null, [arg[0], arg[1]]);
+          },
+          {
+            accepts: { arg: 'arg', type: ['number'] },
+            returns: { arg: 'data', type: ['integer'] },
+            http: { method: 'POST' },
+          });
+
+        request(app).post(method.url)
+          .send({ arg: [1, 2] })
+          .expect(200, { data: [1, 2] })
+          .end(done);
+      });
     });
+
 
     it('should pass an array argument even when non-array passed', function(done) {
       remotes.foo = {
@@ -2261,6 +2298,18 @@ describe('strong-remoting-rest', function() {
       .expect(400)
       .end(done);
   });
+
+  it('rejects multi-item array passed to an integer argument',
+    function(done) {
+      var method = givenSharedStaticMethod(
+        function(arg, cb) { cb(); },
+        { accepts: { arg: 'arg', type: 'integer' }});
+
+      request(app).get(method.url + '?arg=2&arg=3')
+        .expect(400)
+        .end(done);
+    });
+
 
   it('supports "Object" type string', function(done) {
     var method = givenSharedStaticMethod(

--- a/test/shared-method.test.js
+++ b/test/shared-method.test.js
@@ -133,7 +133,7 @@ describe('SharedMethod', function() {
   describe('sharedMethod.invoke', function() {
     it('returns 400 when number argument is `NaN`', function(done) {
       var method = givenSharedMethod({
-        accepts: [{ arg: 'num', type: 'number' }],
+        accepts: { arg: 'num', type: 'number' },
       });
 
       method.invoke('ctx', { num: NaN }, function(err) {
@@ -142,6 +142,125 @@ describe('SharedMethod', function() {
           expect(err.message).to.contain('num must be a number');
           expect(err.statusCode).to.equal(400);
           done();
+        });
+      });
+    });
+    describe('data type: integer', function() {
+      describe('SharedMethod.getType - determine actual type based on value', function() {
+        it('returns type: number for decimal value & integer target type',
+          function() {
+            expect(SharedMethod.getType(15.2, 'integer')).to.equal('number');
+          });
+        it('returns type:integer for intiger value & integer target type',
+          function() {
+            expect(SharedMethod.getType(14, 'integer')).to.equal('integer');
+          });
+      });
+
+      it('returns 400 when integer argument is a decimal number',
+        function(done) {
+          var method = givenSharedMethod({
+            accepts: { arg: 'num', type: 'integer' },
+          });
+
+          method.invoke('ctx', { num: 2.5 }, function(err) {
+            setImmediate(function() {
+              expect(err).to.exist;
+              expect(err.message).to.match(/integer/i);
+              expect(err.statusCode).to.equal(400);
+              done();
+            });
+          });
+        });
+
+      it('returns 400 when integer argument is `NaN`', function(done) {
+        var method = givenSharedMethod({
+          accepts: { arg: 'num', type: 'integer' },
+        });
+
+        method.invoke('ctx', { num: NaN }, function(err) {
+          setImmediate(function() {
+            expect(err).to.exist;
+            expect(err.message).to.match(/integer/i);
+            expect(err.statusCode).to.equal(400);
+            done();
+          });
+        });
+      });
+
+      it('returns 400 when integer argument is not a safe integer',
+        function(done) {
+          var method = givenSharedMethod(
+            function(arg, cb) {
+              return cb({ 'num': arg });
+            },
+            {
+              accepts: { arg: 'num', type: 'integer' },
+            });
+
+          method.invoke('ctx', { num: 2343546576878989879789 }, function(err) {
+            setImmediate(function() {
+              expect(err).to.exist;
+              expect(err.message).to.match(/integer/i);
+              expect(err.statusCode).to.equal(400);
+              done();
+            });
+          });
+        });
+
+      it('treats integer argument of type x.0 as integer', function(done) {
+        var method = givenSharedMethod(
+          function(arg, cb) {
+            return cb({ 'num': arg });
+          },
+          {
+            accepts: { arg: 'num', type: 'integer' },
+          });
+
+        method.invoke('ctx', { num: '12.0' }, function(result) {
+          setImmediate(function() {
+            expect(result.num).to.equal(12);
+            done();
+          });
+        });
+      });
+
+      it('returns 500 for non-integer return value if type: `integer`',
+        function(done) {
+          var method = givenSharedMethod(
+            function(cb) {
+              cb(null, 3.141);
+            },
+            {
+              returns: { arg: 'value', type: 'integer' },
+            });
+
+          method.invoke('ctx', {}, function(err, result) {
+            setImmediate(function() {
+              expect(err).to.exist;
+              expect(err.message).to.match(/integer/i);
+              expect(err.statusCode).to.equal(500);
+              done();
+            });
+          });
+        });
+
+      it('returns 500 if returned value is not a safe integer', function(done) {
+        var method = givenSharedMethod(
+          function(cb) {
+            cb(null, -2343546576878989879789);
+          },
+          {
+            returns: { arg: 'value', type: 'integer' },
+          });
+
+        method.invoke('ctx', {}, function(err, result) {
+          setImmediate(function() {
+            expect(err).to.exist;
+            expect(err.message).to.match(/safe integer/i);
+            expect(err.statusCode).to.equal(500);
+            done();
+          });
         });
       });
     });


### PR DESCRIPTION
all types of numbers, in Javascript, are of only one dataType: `Numbers`.
~~This is a POC~~ Patch to fix #317.
~~Note: Breaks few test cases on local~~

Connect to #317 