### PR TITLE
Stringify query params which are objects as JSON

### DIFF
--- a/lib/http-invocation.js
+++ b/lib/http-invocation.js
@@ -128,7 +128,7 @@ HttpInvocation.prototype._processArg = function(req, verb, query, accept) {
             // From the query string
             if (val !== undefined) {
               query = query || {};
-              query[name] = val;
+              query[name] = serializeQueryStringValue(val, accept);
             }
             break;
           case 'header':
@@ -148,7 +148,7 @@ HttpInvocation.prototype._processArg = function(req, verb, query, accept) {
     // default to query string for GET
     if (val !== undefined) {
       query = query || {};
-      query[name] = val;
+      query[name] = serializeQueryStringValue(val, accept);
     }
   } else {
     // default to storing args on the body for !GET
@@ -158,6 +158,15 @@ HttpInvocation.prototype._processArg = function(req, verb, query, accept) {
 
   return query;
 };
+
+function serializeQueryStringValue(val, accept) {
+  if ((accept.type === 'object' || accept.type === 'string') &&
+    typeof val === 'object') {
+    return JSON.stringify(val);
+  } else {
+    return val;
+  }
+}
 
 /**
  * Build args object from the http context's `req` and `res`.


### PR DESCRIPTION
Stringify query params which are objects in a way in which empty ararys
are preserved instead of removed (default querystring implementation).

fix: https://github.com/strongloop/strong-remoting/issues/324
