### PR TITLE
Introduce support for integer datatype [backport to 2.x]

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -279,6 +279,12 @@ function badArgumentError(msg) {
   return err;
 }
 
+function internalServerError(msg) {
+  var err = new Error(msg);
+  err.statusCode = 500;
+  return err;
+}
+
 function escapeRegex(d) {
   // see http://stackoverflow.com/a/6969486/69868
   return d.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
@@ -312,7 +318,7 @@ function coerceAccepts(uarg, desc) {
     });
   }
 
-  var actualType = SharedMethod.getType(uarg);
+  var actualType = SharedMethod.getType(uarg, targetType);
 
   // convert values to the correct type
   // TODO(bajtos) Move conversions to HttpContext (and friends)
@@ -325,7 +331,7 @@ function coerceAccepts(uarg, desc) {
     // JSON.parse can throw, so catch this error.
     try {
       uarg = convertValueToTargetType(name, uarg, targetType);
-      actualType = SharedMethod.getType(uarg);
+      actualType = SharedMethod.getType(uarg, targetType);
     } catch (e) {
       var message = util.format('invalid value for argument \'%s\' of type ' +
         '\'%s\': %s. Received type was %s. Error: %s',
@@ -363,7 +369,14 @@ function coerceAccepts(uarg, desc) {
   if (actualType === 'number' && Number.isNaN(uarg)) {
     throw new badArgumentError(name + ' must be a number');
   }
-
+  if (actualType === 'integer') {
+    if (Number.isNaN(uarg)) {
+      throw new badArgumentError(name + ' must be an integer');
+    }
+    if (!Number.isSafeInteger(uarg)) {
+      throw new badArgumentError(name + ' must be a safe integer');
+    }
+  }
   return uarg;
 }
 
@@ -389,6 +402,7 @@ function convertToBasicRemotingType(type) {
   switch (type) {
     case 'string':
     case 'number':
+    case 'integer':
     case 'date':
     case 'boolean':
     case 'buffer':
@@ -411,6 +425,7 @@ function convertValueToTargetType(argName, value, targetType) {
     case 'date':
       return new Date(value);
     case 'number':
+    case 'integer':
       return Number(value).valueOf();
     case 'boolean':
       return Boolean(value).valueOf();
@@ -434,16 +449,18 @@ function convertValueToTargetType(argName, value, targetType) {
  * @returns {String} The type name
  */
 
-SharedMethod.getType = function(val) {
+SharedMethod.getType = function(val, targetType) {
   var type = typeof val;
 
   switch (type) {
     case 'undefined':
     case 'boolean':
-    case 'number':
     case 'function':
     case 'string':
       return type;
+    case 'number':
+      return Number.isInteger(val) && targetType === 'integer' ?
+        'integer' : 'number';
     case 'object':
       // null
       if (val === null) {
@@ -535,8 +552,9 @@ SharedMethod.toResult = function(returns, raw, ctx) {
     }
 
     if (item.root) {
-      var isFile = convertToBasicRemotingType(item.type) === 'file';
-      result = isFile ? raw[index] : convert(raw[index]);
+      var targetType = convertToBasicRemotingType(item.type);
+      var isFile =  targetType === 'file';
+      result = isFile ? raw[index] : convert(raw[index], targetType, item.name);
       return false;
     }
 
@@ -545,21 +563,34 @@ SharedMethod.toResult = function(returns, raw, ctx) {
 
   returns.forEach(function(item, index) {
     var name = item.name || item.arg;
-    if (convertToBasicRemotingType(item.type) === 'file') {
+    var targetType = convertToBasicRemotingType(item.type);
+    if (targetType === 'file') {
       console.warn('%s: discarded non-root return argument %s of type "file"',
         this.stringName,
         name);
       return;
     }
 
-    var value = convert(raw[index]);
+    var value = convert(raw[index], targetType, name);
     result[name] = value;
   });
 
   return result;
 
-  function convert(val) {
-    switch (SharedMethod.getType(val)) {
+  function convert(val, targetType, argName) {
+    var targetTypeIsIntegerArray = Array.isArray(targetType) &&
+      targetType.length === 1 && targetType[0] === 'integer';
+
+    if (targetTypeIsIntegerArray && Array.isArray(val)) {
+      var arrayTargetType = targetType[0];
+      return val.map(function(intVal) {
+        return convert(intVal, arrayTargetType, argName);
+      });
+    }
+
+    var actualType = SharedMethod.getType(val, targetType);
+
+    switch (actualType) {
       case 'date':
         return {
           $type: 'date',
@@ -570,9 +601,29 @@ SharedMethod.toResult = function(returns, raw, ctx) {
           $type: 'base64',
           $data: val.toString('base64')
         };
-    }
+      default:
+        if (targetType === 'integer') {
+          var message;
 
-    return val;
+          if (!Number.isInteger(val)) {
+            message = util.format(
+              'Invalid return value for argument \'%s\' of type ' +
+              '\'%s\': %s. Received type was %s.',
+              argName, targetType, val, typeof val);
+            throw internalServerError(message);
+          }
+
+          if (!Number.isSafeInteger(val)) {
+            message = util.format(
+              'Unsafe integer value returned for argument \'%s\' of type ' +
+              '\'%s\': %s.',
+              argName, targetType, val);
+            throw internalServerError(message);
+          }
+          return val;
+        }
+        return val;
+    }
   }
 };
 
@@ -637,4 +688,17 @@ SharedMethod.prototype.addAlias = function(alias) {
   if (this.aliases.indexOf(alias) === -1) {
     this.aliases.push(alias);
   }
+};
+
+// To support Node v.0.10.x
+Number.isInteger = Number.isInteger || function(value) {
+  return typeof value === 'number' &&
+    isFinite(value) &&
+    Math.floor(value) === value;
+};
+
+Number.MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER || Math.pow(2, 53) - 1;
+
+Number.isSafeInteger = Number.isSafeInteger || function(value) {
+  return Number.isInteger(value) && Math.abs(value) <= Number.MAX_SAFE_INTEGER;
 };

--- a/test/rest-coercion/jsonform-integer.suite.js
+++ b/test/rest-coercion/jsonform-integer.suite.js
@@ -1,0 +1,79 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var jsonFormContext = require('./_jsonform.context');
+
+module.exports = function(ctx) {
+  ctx = jsonFormContext(ctx);
+  var EMPTY_BODY = ctx.EMPTY_BODY;
+  var ERROR_BAD_REQUEST = ctx.ERROR_BAD_REQUEST;
+  var verifyTestCases = ctx.verifyTestCases;
+
+  describe('json form - integer - required', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'integer', required: true }, [
+      // Valid values
+      [{ arg: 0 }, 0],
+      [{ arg: 1 }, 1],
+      [{ arg: -1 }, -1],
+
+      // Empty values should trigger ERROR_BAD_REQUEST
+      [EMPTY_BODY, ERROR_BAD_REQUEST],
+      [{ arg: null }, 0], // should be: ERROR_BAD_REQUEST
+      [{ arg: '' }, 0], // should be: ERROR_BAD_REQUEST
+    ]);
+  });
+
+  describe('json form - integer - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'integer' }, [
+      // Empty values
+      [EMPTY_BODY, undefined],
+      [{ arg: null }, 0], // should be: null
+
+      // Valid values
+      [{ arg: 0 }, 0],
+      [{ arg: 1 }, 1],
+      [{ arg: -1 }, -1],
+
+      // Integers larger than MAX_SAFE_INTEGER should trigger ERROR_BAD_REQUEST
+      [{ arg: 2343546576878989879789 }, ERROR_BAD_REQUEST],
+      [{ arg: -2343546576878989879789 }, ERROR_BAD_REQUEST],
+
+      // Scientific notation works
+      [{ arg: 1.234e+3 }, 1.234e+3],
+      [{ arg: -1.234e+3 }, -1.234e+3],
+
+      // Integer-like string values should trigger ERROR_BAD_REQUEST
+      [{ arg: '0' }, 0],
+      [{ arg: '1' }, 1],
+      [{ arg: '-1' }, -1],
+      [{ arg: '2343546576878989879789' }, ERROR_BAD_REQUEST],
+      [{ arg: '-2343546576878989879789' }, ERROR_BAD_REQUEST],
+      [{ arg: '1.234e+30' }, ERROR_BAD_REQUEST],
+      [{ arg: '-1.234e+30' }, ERROR_BAD_REQUEST],
+      [{ arg: '1.234e+3' }, 1.234e+3],
+      [{ arg: '-1.234e+3' }, -1.234e+3],
+
+      // All other non-integer values should trigger ERROR_BAD_REQUEST
+      [{ arg: 1.2 }, ERROR_BAD_REQUEST],
+      [{ arg: -1.2 }, ERROR_BAD_REQUEST],
+      [{ arg: '1.2' }, ERROR_BAD_REQUEST],
+      [{ arg: '-1.2' }, ERROR_BAD_REQUEST],
+      [{ arg: '' }, 0],
+      [{ arg: false }, 0],
+      [{ arg: 'false' }, ERROR_BAD_REQUEST],
+      [{ arg: true }, 1],
+      [{ arg: 'true' }, ERROR_BAD_REQUEST],
+      [{ arg: 'text' }, ERROR_BAD_REQUEST],
+      [{ arg: [] }, 0],
+      [{ arg: [1, 2] }, ERROR_BAD_REQUEST],
+      [{ arg: {}}, ERROR_BAD_REQUEST],
+      [{ arg: { a: true }}, ERROR_BAD_REQUEST],
+    ]);
+  });
+};

--- a/test/rest-coercion/urlencoded-integer.suite.js
+++ b/test/rest-coercion/urlencoded-integer.suite.js
@@ -1,0 +1,73 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: strong-remoting
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+'use strict';
+
+var urlEncodedContext = require('./_urlencoded.context');
+
+module.exports = function(ctx) {
+  suite('query string', urlEncodedContext(ctx, 'qs'));
+  suite('form data', urlEncodedContext(ctx, 'form'));
+};
+
+function suite(prefix, ctx) {
+  var EMPTY_QUERY = ctx.EMPTY_QUERY;
+  var ERROR_BAD_REQUEST = ctx.ERROR_BAD_REQUEST;
+  var verifyTestCases = ctx.verifyTestCases;
+
+  describe(prefix + ' - integer - required', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'integer', required: true }, [
+      // Valid values
+      ['arg=0', 0],
+      ['arg=1', 1],
+      ['arg=-1', -1],
+
+      // Empty values should trigger ERROR_BAD_REQUEST
+      [EMPTY_QUERY, ERROR_BAD_REQUEST],
+      ['arg', 0],
+      ['arg=', 0],
+
+      // Empty-like values should trigger ERROR_BAD_REQUEST too
+      ['arg=undefined', ERROR_BAD_REQUEST],
+      ['arg=null', ERROR_BAD_REQUEST],
+    ]);
+  });
+
+  describe(prefix + ' - integer - optional', function() {
+    // See verifyTestCases' jsdoc for details about the format of test cases.
+    verifyTestCases({ arg: 'arg', type: 'integer' }, [
+      // Empty values
+      [EMPTY_QUERY, undefined],
+      ['arg', 0], // should be: undefined
+      ['arg=', 0], // should be: undefined
+
+      // Valid values
+      ['arg=0', 0],
+      ['arg=1', 1],
+      ['arg=-1', -1],
+
+      // Numbers larger than MAX_SAFE_INTEGER should trigger ERROR_BAD_REQUEST
+      ['arg=2343546576878989879789', ERROR_BAD_REQUEST],
+      ['arg=-2343546576878989879789', ERROR_BAD_REQUEST],
+      // Scientific notation
+      ['arg=1.234e%2B3', 1.234e+3],
+      ['arg=-1.234e%2B3', -1.234e+3],
+
+      // Invalid values should trigger ERROR_BAD_REQUEST
+      ['arg=1.2', ERROR_BAD_REQUEST],
+      ['arg=-1.2', ERROR_BAD_REQUEST],
+      ['arg=undefined', ERROR_BAD_REQUEST],
+      ['arg=null', ERROR_BAD_REQUEST],
+      ['arg=true', ERROR_BAD_REQUEST],
+      ['arg=false', ERROR_BAD_REQUEST],
+      ['arg=text', ERROR_BAD_REQUEST],
+      ['arg=[]', ERROR_BAD_REQUEST],
+      ['arg=[1,2]', ERROR_BAD_REQUEST],
+      ['arg={}', ERROR_BAD_REQUEST],
+      ['arg={"a":true}', ERROR_BAD_REQUEST],
+    ]);
+  });
+}


### PR DESCRIPTION
There is  single datatype in Javascript for
representing numbers: i.e. `numbers`. This is a
patch to fix strong-remoting#317 - a feature
to support data type: `integer`. Includes
following changes:
- Update `convertValueToTargetType()` &
 `convertToBasicRemotingType()`
- Update `SharedMethod.getType()`
- Make `integer` check strict by-default.
 i.e. If argument and/or returned values are
 decimal or `> MAX_SAFE_INTEGER`, for
 argument: send `400`, for returns: send
 `500`
- Rework `convert` method to ignore all arrays
 except "array of integers"
- Add tests to rest-coercion integration
 tests
- Update test cases for integer data type
- Update shared-method.js to include
 support for Node v.0.10.x

This is a back-port of #323
Connect to #317