### PR TITLE
Revert globalization of assert() messages

### DIFF
--- a/lib/shared-class.js
+++ b/lib/shared-class.js
@@ -72,8 +72,7 @@ function SharedClass(name, ctor, options) {
 
     this.sharedCtor = new SharedMethod(ctor.sharedCtor, 'sharedCtor', this);
   }
-  assert(this.name, g.f('must include a {{remoteNamespace}} ' +
-    'when creating a {{SharedClass}}'));
+  assert(this.name, 'must include a remoteNamespace when creating a SharedClass');
 }
 
 /**

--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -95,7 +95,7 @@ function SharedMethod(fn, name, sc, options) {
   this.fn = fn;
   fn = fn || {};
   this.name = name;
-  assert(typeof name === 'string', g.f('The method name must be a {{string}}'));
+  assert(typeof name === 'string', 'The method name must be a string');
   options = options || {};
   this.aliases = options.aliases || [];
   var isStatic = this.isStatic = options.isStatic || false;


### PR DESCRIPTION
This is a partial revert of #329 that added globalization of `assert` messages, which caused performance degradation (strong-globalize is rather slow ATM, see https://github.com/strongloop/strong-globalize/issues/66).

see also #331

cc @0candy @superkhau @deepakrkris 