### PR TITLE
Add new API for finding/disabling remote methods

### DIFF
--- a/lib/shared-class.js
+++ b/lib/shared-class.js
@@ -218,9 +218,33 @@ SharedClass.prototype.find = function(fn, isStatic) {
  */
 
 SharedClass.prototype.disableMethod = function(fn, isStatic) {
-  var disableMethods = this._disabledMethods;
   var key = this.getKeyFromMethodNameAndTarget(fn, isStatic);
-  disableMethods[key] = true;
+  this.disableMethodByName(key);
+};
+
+/**
+ * Find a sharedMethod with the given static or prototype method name.
+ *
+ * @param {String} methodName The method name
+ * Find a static or prototype method with the given name.
+ * @returns {SharedMethod}
+ */
+
+SharedClass.prototype.findMethodByName = function(methodName) {
+  return this.methods().filter(function(method) {
+    return method.isDelegateForName(methodName);
+  })[0];
+};
+
+/**
+ * Disable a sharedMethod with the given static or prototype method name.
+ *
+ * @param {String} methodName The method name
+ */
+
+SharedClass.prototype.disableMethodByName = function(methodName) {
+  var disableMethods = this._disabledMethods;
+  disableMethods[methodName] = true;
 };
 
 /**

--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -146,6 +146,12 @@ function SharedMethod(fn, name, sc, options) {
     this.errors = [this.errors];
   }
 
+  if (/^prototype\./.test(name)) {
+    var msg = 'Incorrect API usage. Shared methods on prototypes should be ' +
+      'created via `new SharedMethod(fn, "name", { isStatic: false })`';
+    throw new Error(msg);
+  }
+
   this.stringName = (sc ? sc.name : '') + (isStatic ? '.' : '.prototype.') + name;
 }
 
@@ -676,6 +682,27 @@ SharedMethod.prototype.isDelegateFor = function(suspect, isStatic) {
   }
 
   return false;
+};
+
+/**
+ * Determine if this shared method invokes the given "suspect" function.
+ *
+ * @example
+ * ```js
+ * sharedMethod.isDelegateForName('myMethod'); // check for a static method by name
+ * sharedMethod.isDelegateForName('prototype.myInstMethod'); // instance method by name
+ * ```
+ *
+ * @returns Boolean True if the shared method invokes the given function; false otherwise.
+ */
+
+SharedMethod.prototype.isDelegateForName = function(suspect) {
+  assert(typeof suspect === 'string', 'argument of isDelegateForName should be string');
+
+  var m = suspect.match(/^prototype\.(.*)$/);
+  var isStatic = !m;
+  var baseName = isStatic ? suspect : m[1];
+  return this.isDelegateFor(baseName, isStatic);
 };
 
 /**

--- a/test/shared-class.test.js
+++ b/test/shared-class.test.js
@@ -56,6 +56,7 @@ describe('SharedClass', function() {
       expect(fns).to.contain(SomeClass.staticMethod);
       expect(fns).to.contain(SomeClass.prototype.instanceMethod);
     });
+
     it('returns all methods when includeDisabled is true', function() {
       var sc = new SharedClass('MySharedClass', MySharedClass);
       function MySharedClass() {
@@ -73,6 +74,7 @@ describe('SharedClass', function() {
 
       expect(outputNames).to.eql(inputNames);
     });
+
     it('only discovers a function once with aliases', function() {
       function MyClass() {}
       var sc = new SharedClass('some', MyClass);
@@ -87,6 +89,7 @@ describe('SharedClass', function() {
       expect(fns.length).to.equal(1);
       expect(methods[0].aliases.sort()).to.eql(['a', 'b']);
     });
+
     it('discovers multiple functions correctly', function() {
       function MyClass() {}
       var sc = new SharedClass('some', MyClass);
@@ -106,6 +109,7 @@ describe('SharedClass', function() {
         return fn;
       }
     });
+
     it('should skip properties that are model classes', function() {
       var sc = new SharedClass('some', SomeClass);
       function MockModel1() {}
@@ -129,7 +133,7 @@ describe('SharedClass', function() {
       SomeClass.prototype.myMethod = function() {};
       var METHOD_NAME = 'myMethod';
       sc.defineMethod(METHOD_NAME, {
-        prototype: true
+        prototype: true,
       });
       var methods = sc.methods().map(getName);
       expect(methods).to.contain(METHOD_NAME);
@@ -198,11 +202,31 @@ describe('SharedClass', function() {
         prototype: true
       });
     });
+
     it('finds sharedMethod for the given function', function() {
       assert(sc.find(SomeClass.prototype.myMethod) === sm);
     });
+
     it('find sharedMethod by name', function() {
       assert(sc.find('myMethod') === sm);
+    });
+  });
+
+  describe('sharedClass.findMethodByName()', function() {
+    it('finds sharedMethod by prototype method name', function() {
+      var sc = new SharedClass('SomeClass', SomeClass);
+      var sm = sc.defineMethod('testMethod', {
+        isStatic: false
+      });
+      assert(sc.findMethodByName('prototype.testMethod') === sm);
+    });
+
+    it('find sharedMethod by static method name', function() {
+      var sc = new SharedClass('SomeClass', SomeClass);
+      var sm = sc.defineMethod('myMethod', {
+        isStatic: true
+      });
+      assert(sc.findMethodByName('myMethod') === sm);
     });
   });
 
@@ -250,6 +274,27 @@ describe('SharedClass', function() {
       sc.disableMethod(DYN_METHOD_NAME, true);
       var methods = sc.methods().map(getName);
       expect(methods).to.not.contain(DYN_METHOD_NAME);
+    });
+  });
+
+  describe('sharedClass.disableMethodByName(methodName)', function() {
+    it('excludes disabled static methods from the method list', function() {
+      var METHOD_NAME = 'testMethod';
+      var sc = new SharedClass('SomeClass', SomeClass);
+      var sm = sc.defineMethod(METHOD_NAME, {isStatic: true});
+      sc.disableMethodByName(METHOD_NAME);
+      var methods = sc.methods().map(getName);
+      expect(methods).to.not.contain(METHOD_NAME);
+    });
+
+    it('excludes disabled prototype methods from the method list', function() {
+      var INST_METHOD_NAME = 'prototype.instTestMethod';
+      var sc = new SharedClass('SomeClass', SomeClass);
+      var sm = sc.defineMethod('instTestMethod', {isStatic: false});
+      sc.disableMethodByName(INST_METHOD_NAME);
+      var methods = sc.methods().map(getName);
+      expect(methods).to.not.contain(INST_METHOD_NAME);
+      expect(methods).to.not.contain('instTestMethod');
     });
   });
 });

--- a/test/shared-method.test.js
+++ b/test/shared-method.test.js
@@ -91,6 +91,47 @@ describe('SharedMethod', function() {
     });
   });
 
+  describe('sharedMethod.isDelegateForName(suspect)', function() {
+
+    // stub function
+    function myFunction() {}
+
+    it('checks by name if static function is going to be invoked', function() {
+      var mockSharedClass = { myName: myFunction };
+      var options = { isStatic: true };
+      var sharedMethod = new SharedMethod(myFunction, 'myName', mockSharedClass, options);
+      assert.equal(sharedMethod.isDelegateForName('myName'), true);
+    });
+
+    it('checks by alias if static function is going to be invoked', function() {
+      var mockSharedClass = { myName: myFunction };
+      var options = { isStatic: true, aliases: ['myAlias'] };
+      var sharedMethod = new SharedMethod(myFunction, 'myName', mockSharedClass, options);
+      assert.equal(sharedMethod.isDelegateForName('myAlias'), true);
+    });
+
+    it('checks by name if prototype function is going to be invoked', function() {
+      var mockSharedClass = { myName: myFunction };
+      var options = { isStatic: false };
+      var sharedMethod = new SharedMethod(myFunction, 'myName', mockSharedClass, options);
+      assert.equal(sharedMethod.isDelegateForName('prototype.myName'), true);
+    });
+
+    it('checks by alias if prototype function is going to be invoked', function() {
+      var mockSharedClass = { myName: myFunction };
+      var options = { isStatic: false, aliases: ['myAlias'] };
+      var sharedMethod = new SharedMethod(myFunction, 'myName', mockSharedClass, options);
+      assert.equal(sharedMethod.isDelegateForName('prototype.myAlias'), true);
+    });
+
+    it('checks if the given name is a string', function() {
+      var mockSharedClass = {};
+      var err;
+      var sharedMethod = new SharedMethod(myFunction, 'myName', mockSharedClass);
+      expect(function() { sharedMethod.isDelegateForName(myFunction); }).to.throw(/argument.*string/);
+    });
+  });
+
   describe('sharedMethod.invoke', function() {
     it('returns 400 when number argument is `NaN`', function(done) {
       var method = givenSharedMethod({


### PR DESCRIPTION
This is a back-port of #275 excluding the deprecation warnings.

If we included deprecation warnings, then I think tools like loopback-swagger and loopback-sdk-angular will start reporting these deprecations, because IIRC they are still using the old API. Thus I think it's better to buy us more time by not deprecating the old methods yet.

@0candy please review
cc @Amir-61 @davidcheung 