### PR TITLE
[SEMVER-MAJOR] Fix Date serialization

### DIFF
--- a/3.0-RELEASE-NOTES.md
+++ b/3.0-RELEASE-NOTES.md
@@ -176,3 +176,35 @@ correctly encodes request parameters.
 
 See [pull request #343](https://github.com/strongloop/strong-remoting/pull/343)
 for more details.
+
+## Serialization of Date values in responses
+
+The format of date values has been changed from the output of `.toString()`,
+which produces values in local timezone, to the output of `.toJSON()`, which
+produces values in GMT.
+
+For example, let's take `new Date(0)` returned for `dateArgument`.
+
+In strong-remoting 2.x, this value is converted to the following response
+when running on a computer in the Central-European timezone:
+
+```json
+{
+  "dateArgument": {
+    "$type": "date",
+    "$data": "Thu Jan 01 1970 01:00:00 GMT+0100 (CET)"
+  }
+}
+```
+
+In strong-remoting 3.x, the same value is converted to the following response
+regardless of the server timezone settings:
+
+```json
+{
+  "dateArgument": {
+    "$type": "date",
+    "$data": "1970-01-01T00:00:00.000Z"
+  }
+}
+```

--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -516,7 +516,7 @@ SharedMethod.toResult = function(returns, raw, ctx) {
       case 'date':
         return {
           $type: 'date',
-          $data: val.toString(),
+          $data: val.toJSON ? val.toJSON() : val.toString(),
         };
       case 'buffer':
         return {

--- a/test/shared-method.test.js
+++ b/test/shared-method.test.js
@@ -268,6 +268,31 @@ describe('SharedMethod', function() {
       });
     });
 
+    describe('data type: Date', function() {
+      it('converts return values to GMT timezone', function(done) {
+        var method = givenSharedMethod(
+          function(cb) {
+            cb(null, new Date(0));
+          },
+          {
+            returns: { arg: 'value', type: 'date' },
+          });
+
+        method.invoke('ctx', {}, {}, ctx(method), function(err, result) {
+          setImmediate(function() {
+            if (err) return done(err);
+            expect(result).to.eql({
+              value: {
+                $type: 'date',
+                $data: '1970-01-01T00:00:00.000Z',
+              },
+            });
+            done();
+          });
+        });
+      });
+    });
+
     it('returns 400 and doesn\'t crash with unparsable object', function(done) {
       var method = givenSharedMethod({
         accepts: [{ arg: 'obj', type: 'object' }],


### PR DESCRIPTION
Change the format of Date "returns" arguments from the output of `.toString()`, which produces values in local timezone, to the output of `.toJSON()`, which produces values in GMT.

Before:

    {
      "$type": "date",
      "$data": "Thu Jan 01 1970 01:00:00 GMT+0100 (CET)"
    }

Now:

    {
      "$type": "date",
      "$data": "1970-01-01T00:00:00.000Z"
    }

Connect to strongloop/loopback#1990

@ritch please review
@gunjpan @richardpringle @deepakrkris PTAL too

Note: in the issue strongloop/loopback#1990, I am proposing a more radical change. Unfortunately, it also requires more time which we don't have right now. 