### PR TITLE
Fix tests to use res.get instead of res.headers

### DIFF
--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -336,8 +336,8 @@ describe('strong-remoting-rest', function() {
         .set('Origin', url)
         .send({ person: 'ABC' })
         .end(function(err, res) {
-          assert(res.headers['Access-Control-Allow-Origin'] === undefined);
-          assert(res.headers['Access-Control-Allow-Credentials'] === undefined);
+          assert(res.get('Access-Control-Allow-Origin') === undefined);
+          assert(res.get('Access-Control-Allow-Credentials') === undefined);
           done();
         });
     });


### PR DESCRIPTION
The latter is case-sensitive and expects header names in lower-case.

See also the discussion in #293 

@STRML please review