### PR TITLE
Add rest-coercion tests for zero-prefixed numbers

### DIFF
--- a/test/rest-coercion/urlencoded-any.suite.js
+++ b/test/rest-coercion/urlencoded-any.suite.js
@@ -62,6 +62,11 @@ function suite(prefix, ctx) {
       ['arg=2343546576878989879789', 2.34354657687899e+21],
       // This should have been recognized as number
       ['arg=-2343546576878989879789', '-2343546576878989879789'],
+      // Numbers starting with a leading zero are treated as strings
+      // See https://github.com/strongloop/strong-remoting/issues/143
+      ['arg=0668', '0668'],
+      // However, floats are correctly parsed
+      ['arg=0.42', 0.42],
       // Scientific notation should be recognized as a number
       ['arg=1.234e%2B30', '1.234e+30'],
       ['arg=-1.234e%2B30', '-1.234e+30'],

--- a/test/rest-coercion/urlencoded-array.suite.js
+++ b/test/rest-coercion/urlencoded-array.suite.js
@@ -127,6 +127,12 @@ function suite(prefix, ctx) {
       ['arg={}', ERROR_BAD_REQUEST],
       ['arg={"a":true}', ERROR_BAD_REQUEST],
 
+      // Numbers starting with a leading zero are parsed,
+      // because we know the expected type is a number.
+      // See https://github.com/strongloop/strong-remoting/issues/143
+      ['arg=0668', [668]],
+      ['arg=0.42', [0.42]],
+
       // Malformed JSON should trigger ERROR_BAD_REQUEST
       ['arg={malformed}', ERROR_BAD_REQUEST],
       ['arg=[malformed]', ERROR_BAD_REQUEST],
@@ -157,6 +163,11 @@ function suite(prefix, ctx) {
       // Valid values - JSON encoding
       ['arg=[]', []],
       ['arg=[1,2]', ['1', '2']],
+
+      // Numbers starting with a leading zero are treated as strings
+      // See https://github.com/strongloop/strong-remoting/issues/143
+      ['arg=0668', ['0668']],
+      ['arg=0.42', ['0.42']],
 
       // Invalid values should trigger ERROR_BAD_REQUEST
       ['arg={}', ['{}']],
@@ -246,6 +257,12 @@ function suite(prefix, ctx) {
       ['arg=-2343546576878989879789', ['-2343546576878989879789']],
       // Scientific notation - should it be recognized as a number?
       ['arg=1.234e%2B30&arg=-1.234e%2B30', ['1.234e+30', '-1.234e+30']],
+
+      // Integers starting with a leading zero are treated as strings
+      // See https://github.com/strongloop/strong-remoting/issues/143
+      ['arg=0668', ['0668']],
+      // However, floats are correctly parsed
+      ['arg=0.42', [0.42]],
 
       // Valid values - JSON encoding
       ['arg=[]', []],

--- a/test/rest-coercion/urlencoded-integer.suite.js
+++ b/test/rest-coercion/urlencoded-integer.suite.js
@@ -68,6 +68,12 @@ function suite(prefix, ctx) {
       ['arg=[1,2]', ERROR_BAD_REQUEST],
       ['arg={}', ERROR_BAD_REQUEST],
       ['arg={"a":true}', ERROR_BAD_REQUEST],
+
+      // Numbers starting with a leading zero are parsed,
+      // because we know the expected type is a number.
+      // See https://github.com/strongloop/strong-remoting/issues/143
+      ['arg=0668', 668],
+      ['arg=0.42', ERROR_BAD_REQUEST], // not an integer
     ]);
   });
 }

--- a/test/rest-coercion/urlencoded-number.suite.js
+++ b/test/rest-coercion/urlencoded-number.suite.js
@@ -67,6 +67,12 @@ function suite(prefix, ctx) {
       ['arg=[1,2]', ERROR_BAD_REQUEST],
       ['arg={}', ERROR_BAD_REQUEST],
       ['arg={"a":true}', ERROR_BAD_REQUEST],
+
+      // Numbers starting with a leading zero are parsed,
+      // because we know the expected type is a number.
+      // See https://github.com/strongloop/strong-remoting/issues/143
+      ['arg=0668', 668],
+      ['arg=0.42', 0.42],
     ]);
   });
 }

--- a/test/rest-coercion/urlencoded-string.suite.js
+++ b/test/rest-coercion/urlencoded-string.suite.js
@@ -62,6 +62,11 @@ function suite(prefix, ctx) {
       // Scientific notation
       ['arg=1.234e%2B30', '1.234e+30'],
       ['arg=-1.234e%2B30', '-1.234e+30'],
+
+      // Numbers starting with a leading zero are treated as strings
+      // See https://github.com/strongloop/strong-remoting/issues/143
+      ['arg=0668', '0668'],
+      ['arg=0.42', '0.42'],
     ]);
   });
 }


### PR DESCRIPTION
Add tests describing behaviour for numbers with a leading zero, see https://github.com/strongloop/strong-remoting/issues/143.

- When the argument's type is `any`, strong-remoting will treat integer numbers starting with `0` as string, e.g. `0668` will preserve the leading zero. However, floats are still converted to numbers, e.g. both `0.42` and `00.42` are converted to a number.

- When the argument's type is `number` or `integer`, strong-remoting will treat integer numbers starting with `0` as numbers and discarding any extra leading zeroes.

Forward-port #346
Connect to #312 
