### PR TITLE
Detect JSON content-type with parameters

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -112,13 +112,14 @@ HttpContext.prototype.buildArgs = function(method) {
   var ctx = this;
   var accepts = method.accepts;
 
+  var isJsonRequest = /^application\/json\b/.test(ctx.req.get('content-type'));
+
   // build arguments from req and method options
   for (var i = 0, n = accepts.length; i < n; i++) {
     var o = accepts[i];
     var httpFormat = o.http;
     var name = o.name || o.arg;
     var val;
-    var isJsonRequest = ctx.req.get('content-type') === 'application/json';
 
     var typeConverter = ctx.typeRegistry.getConverter(o.type);
 

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -2277,6 +2277,26 @@ describe('strong-remoting-rest', function() {
       });
   });
 
+  it('detects json type with charset definition', function(done) {
+    var method = givenSharedStaticMethod(
+      function(arg, cb) { cb(null, arg); },
+      {
+        accepts: { arg: 'arg', type: 'any', http: { source: 'form' }},
+        returns: { arg: 'arg', type: 'any' },
+      });
+
+    request(app).post(method.url)
+      .set('Content-Type', 'application/json;charset=UTF-8')
+      .send({ arg: '123' })
+      .expect(200)
+      .end(function(err, res) {
+        if (err) return done(err);
+        // JSON request was detected, sloppy coercion was not triggered
+        expect(res.body.arg).to.equal('123');
+        done();
+      });
+  });
+
   it('rejects multi-item array passed to a number argument', function(done) {
     var method = givenSharedStaticMethod(
       function(arg, cb) { cb(); },


### PR DESCRIPTION
Fix the detection of JSON content type used to decide whether sloppy
coercion should be applied, so that it correctly supports values with
parameters. For example:

    application/json;charset=UTF-8

Connect to #267

@richardpringle please review
cc @ebourmalo