### PR TITLE
[SEMVER-MAJOR] Remove built-in CORS middleware

### DIFF
--- a/3.0-RELEASE-NOTES.md
+++ b/3.0-RELEASE-NOTES.md
@@ -219,3 +219,73 @@ regardless of the server timezone settings:
 ```
 
 See [pull request #344](https://github.com/strongloop/strong-remoting/pull/344) for more details.
+
+## CORS is no longer enabled
+
+There are two types of applications that are commonly built using LoopBack,
+and each type has different requirements when it comes to CORS.
+
+ 1. Public facing API servers serving a variety of clients.
+  CORS should be enabled to allow 3rd party sites to access the API server
+  living on a different domain.
+
+ 2. API+SPA sites where both API and the SPA client live on the same domain
+  and the API should be locked down to serve only its own browser clients,
+  i.e. CORS must be disabled.
+
+By enabling CORS by default, we were making API+SPA sites vulnerable by default.
+
+In strong-remoting 3.x, we removed the built-in CORS middleware and pushed
+the responsibility for enabling and configuring CORS back to application
+developers.
+
+Note that this does not affect LoopBack applications scaffolded by a recent
+version of `slc loopback` or `apic loopback`, as these applications don't rely
+on the built-in CORS middleware and configure CORS explicitly
+in `server/middleware.json`.
+
+If your application relies on the built-in CORS middleware that used to be
+provided by strong-remoting/loopback, then please make the following changes
+to upgrade your application:
+
+1) `npm install --save cors`
+
+2a) If you are using loopback-boot, then add the following entry to your
+`server/middleware.json` file:
+
+```js
+{
+  // ...
+  "initial": {
+    // ...
+    "cors": {
+      "params": {
+        "origin": true,
+        "credentials": true,
+        "maxAge": 86400
+      }
+    },
+    // ...
+  },
+  // ...
+}
+```
+
+2b) If you are not using loopback-boot, then configure the `cors` middleware
+in your server script:
+
+```js
+// ...
+
+var cors = require('cors');
+app.use(cors({ origin: true, credentials: true, maxAge: 86400 }));
+
+// ...
+```
+
+It's important to add the `cors` middleware early, before any request-parsing
+middleware.
+
+See [pull request #352](https://github.com/strongloop/strong-remoting/pull/352) and
+[Security considerations](https://docs.strongloop.com/display/public/LB/Security+considerations)
+for more details.

--- a/lib/jsonrpc-adapter.js
+++ b/lib/jsonrpc-adapter.js
@@ -20,7 +20,6 @@ var inherits = util.inherits;
 var jayson = require('jayson');
 var express = require('express');
 var bodyParser = require('body-parser');
-var cors = require('cors');
 var HttpContext = require('./http-context');
 
 var json = bodyParser.json;
@@ -123,6 +122,17 @@ var mockWrapper = [
 
 /* istanbul ignore next */
 JsonRpcAdapter.prototype.createHandler = function() {
+  var corsOptions = this.remotes.options.cors;
+  if (corsOptions !== undefined && corsOptions !== false) {
+    throw new Error(g.f(
+      'The REST adapter no longer comes with a built-in CORS middleware, ' +
+        'the config option %j is no longer available.' +
+        'See %s for more details.',
+      'remoting.cors',
+      'https://docs.strongloop.com/display/public/LB/Security+considerations'
+    ));
+  }
+
   var root = express.Router();
   var classes = this.remotes.classes();
 
@@ -141,23 +151,6 @@ JsonRpcAdapter.prototype.createHandler = function() {
   // Set strict to be `false` so that anything `JSON.parse()` accepts will be parsed
   debug('remoting options: %j', this.remotes.options);
   var jsonOptions = this.remotes.options.json || { strict: false };
-  var corsOptions = this.remotes.options.cors;
-  if (corsOptions === undefined) corsOptions = { origin: true, credentials: true };
-
-  // Optimize the cors handler
-  var corsHandler = function(req, res, next) {
-    var reqUrl = req.protocol + '://' + req.get('host');
-    if (req.method === 'OPTIONS' || reqUrl !== req.get('origin')) {
-      cors(corsOptions)(req, res, next);
-    } else {
-      next();
-    }
-  };
-
-  // Set up CORS first so that it's always enabled even when parsing errors
-  // happen in urlencoded/json
-  if (corsOptions)
-    root.use(corsHandler);
 
   root.use(json(jsonOptions));
 

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -24,7 +24,6 @@ var inherits = util.inherits;
 var assert = require('assert');
 var express = require('express');
 var bodyParser = require('body-parser');
-var cors = require('cors');
 var async = require('async');
 var HttpInvocation = require('./http-invocation');
 var HttpContext = require('./http-context');
@@ -219,6 +218,17 @@ function sortRoutes(r1, r2) {
 RestAdapter.sortRoutes = sortRoutes; // For testing
 
 RestAdapter.prototype.createHandler = function() {
+  var corsOptions = this.remotes.options.cors;
+  if (corsOptions !== undefined && corsOptions !== false) {
+    throw new Error(g.f(
+      'The REST adapter no longer comes with a built-in CORS middleware, ' +
+        'the config option %j is no longer available.' +
+        'See %s for more details.',
+      'remoting.cors',
+      'https://docs.strongloop.com/display/public/LB/Security+considerations'
+    ));
+  }
+
   var root = express.Router();
   var adapter = this;
   var classes = this.getClasses();
@@ -242,23 +252,6 @@ RestAdapter.prototype.createHandler = function() {
     urlencodedOptions.extended = true;
   }
   var jsonOptions = this.remotes.options.json || { strict: false };
-  var corsOptions = this.remotes.options.cors;
-  if (corsOptions === undefined) corsOptions = { origin: true, credentials: true };
-
-  // Optimize the cors handler
-  var corsHandler = function(req, res, next) {
-    var reqUrl = req.protocol + '://' + req.get('host');
-    if (req.method === 'OPTIONS' || reqUrl !== req.get('origin')) {
-      cors(corsOptions)(req, res, next);
-    } else {
-      next();
-    }
-  };
-
-  // Set up CORS first so that it's always enabled even when parsing errors
-  // happen in urlencoded/json
-  if (corsOptions)
-    root.use(corsHandler);
 
   root.use(urlencoded(urlencodedOptions));
   root.use(json(jsonOptions));

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "async": "^2.0.1",
     "body-parser": "^1.12.4",
-    "cors": "^2.6.0",
     "debug": "^2.2.0",
     "depd": "^1.1.0",
     "eventemitter2": "^2.1.0",
@@ -75,7 +74,6 @@
   "browser": {
     "express": false,
     "body-parser": false,
-    "cors": false,
     "js2xmlparser": false,
     "strong-error-handler": false
   },

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -299,7 +299,7 @@ describe('strong-remoting-rest', function() {
     });
   });
 
-  describe('cors', function() {
+  describe('CORS', function() {
     var method;
     beforeEach(function() {
       method = givenSharedStaticMethod(
@@ -319,67 +319,22 @@ describe('strong-remoting-rest', function() {
       );
     });
 
-    it('should support cors', function(done) {
+    it('should reject cross-origin requests', function(done) {
       request(app).post(method.url)
         .set('Accept', 'application/json')
         .set('Content-Type', 'application/json')
         .set('Origin', 'http://localhost:3001')
         .send({ person: 'ABC' })
-        .expect('Access-Control-Allow-Origin', 'http://localhost:3001')
-        .expect('Access-Control-Allow-Credentials', 'true')
-        .expect(200, done);
-    });
-
-    it('should skip cors if origin is the same as the request url', function(done) {
-      var server = request(app).post(method.url);
-      var url = server.url.replace('/testClass/testMethod', '');
-      server
-        .set('Accept', 'application/json')
-        .set('Content-Type', 'application/json')
-        .set('Origin', url)
-        .send({ person: 'ABC' })
-        .end(function(err, res) {
-          assert(res.get('Access-Control-Allow-Origin') === undefined);
-          assert(res.get('Access-Control-Allow-Credentials') === undefined);
+        .expect(200, function(err, res) {
+          expect(Object.keys(res.headers)).to.not.include.members([
+            'access-control-allow-origin',
+            'access-control-allow-credentials',
+          ]);
           done();
         });
     });
 
-    it('should support cors preflight', function(done) {
-      request(app).options(method.url)
-        .set('Accept', 'application/json')
-        .set('Content-Type', 'application/json')
-        .set('Origin', 'http://localhost:3001')
-        .send()
-        .expect('Access-Control-Allow-Origin', 'http://localhost:3001')
-        .expect('Access-Control-Allow-Credentials', 'true')
-        .expect(204, done);
-    });
-
-    it('should support cors when errors happen', function(done) {
-      request(app).post(method.url)
-        .set('Accept', 'application/json')
-        .set('Content-Type', 'application/json')
-        .set('Origin', 'http://localhost:3001')
-        .send({ person: 'error' })
-        .expect('Access-Control-Allow-Origin', 'http://localhost:3001')
-        .expect('Access-Control-Allow-Credentials', 'true')
-        .expect(400, done);
-    });
-
-    it('should support cors when parsing errors happen', function(done) {
-      request(app).post(method.url)
-        .set('Accept', 'application/json')
-        .set('Content-Type', 'application/json')
-        .set('Origin', 'http://localhost:3001')
-        .send('ABC') // invalid json
-        .expect('Access-Control-Allow-Origin', 'http://localhost:3001')
-        .expect('Access-Control-Allow-Credentials', 'true')
-        .expect(400, done);
-    });
-
-    it('OPTIONS requests should skip cors if config is false', function(done) {
-      objects.options.cors = false;
+    it('should reject preflight (OPTIONS) requests', function(done) {
       request(app).options(method.url)
         .set('Accept', 'application/json')
         .set('Content-Type', 'application/json')
@@ -387,21 +342,11 @@ describe('strong-remoting-rest', function() {
         .send()
         // http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.2
         .expect(200, function(err, res) {
-          expect(res.get('Access-Control-Allow-Origin')).to.not.exist;
-          done(err, res);
-        });
-    });
-
-    it('should skip cors headers if config is false', function(done) {
-      objects.options.cors = false;
-      request(app).post(method.url)
-        .set('Accept', 'application/json')
-        .set('Content-Type', 'application/json')
-        .set('Origin', 'http://localhost:3001')
-        .send({ person: 'ABC' })
-        .expect(200, function(err, res) {
-          expect(res.get('Access-Control-Allow-Origin')).to.not.exist;
-          done(err, res);
+          expect(Object.keys(res.headers)).to.not.include.members([
+            'access-control-allow-origin',
+            'access-control-allow-credentials',
+          ]);
+          done();
         });
     });
   });


### PR DESCRIPTION
Following the discussion in https://github.com/strongloop/strong-remoting/pull/293, I would like to revisit the way how CORS is configured in LoopBack applications.

There are two types of applications that are commonly built using LoopBack, and each type has different requirements when it comes to CORS.

 1. Public facing API servers serving a variety of clients. CORS should be enabled to allow 3rd party sites to access the API server living on a different domain than the client(s).
 2. API+[SPA](https://en.wikipedia.org/wiki/Single-page_application) sites where both the API server and the SPA client live on the same domain and the API should be locked down to serve only its own browser clients, i.e. CORS must be disabled.

So far, we were enabling CORS by default to make it easy to build public facing API servers. Unfortunately, this was also making API+SPA sites powered by strong-remoting unsecure by default. What's even worse, this insecure setting was not immediately obvious.

**In this pull request, I am removing CORS from strong-remoting, to push the responsibility of enabling/configuring CORS back to the application developer.**

Note that this change does not affect LoopBack applications scaffolded by a recent version of `slc loopback` or `apic loopback`, as these applications don't rely on the built-in CORS middleware - they configure CORS explicitly in `server/middleware.json`. (See the project template in loopback-workspace, it is disabling the built-in CORS middleware [here](https://github.com/strongloop/loopback-workspace/blob/3e80fcd3053199c5de549a5ded5e7773ad2fc5cc/templates/projects/empty-server/data.js#L82) and explicitly configuring CORS for the entire server [here](https://github.com/strongloop/loopback-workspace/blob/3e80fcd3053199c5de549a5ded5e7773ad2fc5cc/templates/projects/empty-server/files/server/middleware.json#L7-L13).

@richardpringle @STRML please review
cc @gunjpan @deepakrkris @raymondfeng @ritch
