### PR TITLE
Don't convert arg values returned by http function

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -415,12 +415,16 @@ SharedMethod.getType = function(val, targetType) {
  */
 
 SharedMethod.convertArg = function(accept, raw) {
-  if (accept.http && (accept.http.source === 'req' ||
+  var isComputedArgument = accept.http && (
+    typeof accept.http === 'function' ||
+    accept.http.source === 'req' ||
     accept.http.source === 'res' ||
-    accept.http.source === 'context'
-    )) {
+    accept.http.source === 'context');
+
+  if (isComputedArgument) {
     return raw;
   }
+
   if (raw === null || typeof raw !== 'object') {
     return raw;
   }


### PR DESCRIPTION
When an argument provides "http" mapping as a custom function, then we should not traverse the return value to detect buffers and dates. The return value could be a complex object, e.g. the full remoting context, in which case the traversal takes too long (in order of seconds!).

I discovered this issue while playing with a solution for injecting context via `options` argument (see https://github.com/strongloop/loopback/issues/1495 and the pull request https://github.com/strongloop/loopback/pull/2762).

@ritch @richardpringle or @deepakrkris please review