### PR TITLE
Deprecate built-in CORS middleware

### DIFF
--- a/lib/jsonrpc-adapter.js
+++ b/lib/jsonrpc-adapter.js
@@ -15,6 +15,7 @@ module.exports = JsonRpcAdapter;
 
 var EventEmitter = require('events').EventEmitter;
 var debug = require('debug')('strong-remoting:jsonrpc-adapter');
+var deprecated = require('depd')('strong-remoting');
 var util = require('util');
 var inherits = util.inherits;
 var jayson = require('jayson');
@@ -144,6 +145,14 @@ JsonRpcAdapter.prototype.createHandler = function() {
   var jsonOptions = this.remotes.options.json || {strict: false};
   var corsOptions = this.remotes.options.cors;
   if (corsOptions === undefined) corsOptions = {origin: true, credentials: true};
+
+  if (corsOptions !== false) {
+    deprecated(g.f(
+      'The built-in CORS middleware provided by JsonRpc adapter ' +
+        'was deprecated. See %s for more details.',
+      'https://docs.strongloop.com/display/public/LB/Security+considerations'
+    ));
+  }
 
   // Optimize the cors handler
   var corsHandler = function(req, res, next) {

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -19,6 +19,7 @@ RestAdapter.RestMethod = RestMethod;
 var deprecated = require('depd')('strong-remoting');
 var EventEmitter = require('events').EventEmitter;
 var debug = require('debug')('strong-remoting:rest-adapter');
+var deprecated = require('depd')('strong-remoting');
 var util = require('util');
 var inherits = util.inherits;
 var assert = require('assert');
@@ -243,6 +244,14 @@ RestAdapter.prototype.createHandler = function() {
   var jsonOptions = this.remotes.options.json || {strict: false};
   var corsOptions = this.remotes.options.cors;
   if (corsOptions === undefined) corsOptions = {origin: true, credentials: true};
+
+  if (corsOptions !== false) {
+    deprecated(g.f(
+      'The built-in CORS middleware provided by REST adapter ' +
+        'was deprecated. See %s for more details.',
+      'https://docs.strongloop.com/display/public/LB/Security+considerations'
+    ));
+  }
 
   // Optimize the cors handler
   var corsHandler = function(req, res, next) {

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -14,7 +14,7 @@ var User = require('./e2e/fixtures/user');
 
 describe('support for HTTP Authentication', function() {
   var server;
-  var remotes = RemoteObjects.create();
+  var remotes = RemoteObjects.create({cors: false});
   remotes.exports.User = User;
 
   before(function setupServer(done) {

--- a/test/authorize-hook.test.js
+++ b/test/authorize-hook.test.js
@@ -16,7 +16,7 @@ describe('authorization hook', function() {
 
   before(function setupServer(done) {
     var app = express();
-    remotes = RemoteObjects.create();
+    remotes = RemoteObjects.create({cors: false});
     remotes.exports.User = User;
     app.use(remotes.handler('rest'));
     server = app.listen(0, '127.0.0.1', done);

--- a/test/jsonrpc.test.js
+++ b/test/jsonrpc.test.js
@@ -18,7 +18,7 @@ describe('strong-remoting-jsonrpc', function() {
   // setup
   beforeEach(function() {
     if (server) server.close();
-    objects = RemoteObjects.create({json: {limit: '1kb'}});
+    objects = RemoteObjects.create({json: {limit: '1kb'}, cors: false});
     remotes = objects.exports;
     app = express();
   });

--- a/test/phase-handlers.test.js
+++ b/test/phase-handlers.test.js
@@ -13,7 +13,7 @@ describe('phase handlers', function() {
 
   beforeEach(function setupServer(done) {
     var app = express();
-    remotes = RemoteObjects.create();
+    remotes = RemoteObjects.create({cors: false});
     remotes.exports.User = User;
     app.use(function(req, res, next) {
       // always build a new handler to pick new methods added by tests
@@ -23,7 +23,7 @@ describe('phase handlers', function() {
   });
 
   beforeEach(function setupClient() {
-    clientRemotes = RemoteObjects.create();
+    clientRemotes = RemoteObjects.create({cors: false});
     clientRemotes.exports.User = User;
     var url = 'http://127.0.0.1:' + server.address().port;
     clientRemotes.connect(url, 'rest');

--- a/test/rest-adapter.test.js
+++ b/test/rest-adapter.test.js
@@ -19,7 +19,7 @@ describe('RestAdapter', function() {
   var remotes;
 
   beforeEach(function() {
-    remotes = RemoteObjects.create();
+    remotes = RemoteObjects.create({cors: false});
   });
 
   describe('getClasses()', function() {
@@ -383,7 +383,7 @@ describe('RestAdapter', function() {
     var remotes, req, res;
 
     beforeEach(function() {
-      remotes = RemoteObjects.create();
+      remotes = RemoteObjects.create({cors: false});
       req = false;
       res = false;
 

--- a/test/rest-coercion.test.js
+++ b/test/rest-coercion.test.js
@@ -58,6 +58,7 @@ describe('Coercion in RestAdapter', function() {
   function setupRemoteObjects() {
     ctx.remoteObjects = RemoteObjects.create({
       errorHandler: { debug: true, log: false },
+      cors: false,
     });
   }
 

--- a/test/rest.browser.test.js
+++ b/test/rest.browser.test.js
@@ -30,7 +30,7 @@ describe('strong-remoting-rest', function() {
 
   // setup
   beforeEach(function() {
-    objects = RemoteObjects.create();
+    objects = RemoteObjects.create({cors: false});
     remotes = objects.exports;
 
     // connect to the app

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -54,8 +54,11 @@ describe('strong-remoting-rest', function() {
     if (process.env.NODE_ENV === 'production') {
       process.env.NODE_ENV = 'test';
     }
-    objects = RemoteObjects.create({json: {limit: '1kb'},
-      errorHandler: {disableStackTrace: false}});
+    objects = RemoteObjects.create({
+      json: {limit: '1kb'},
+      errorHandler: {disableStackTrace: false},
+      cors: false,
+    });
     remotes = objects.exports;
 
     // connect to the app
@@ -325,6 +328,9 @@ describe('strong-remoting-rest', function() {
   describe('cors', function() {
     var method;
     beforeEach(function() {
+      delete objects.options.cors; // use the default setting
+      process.once('deprecation', function() { /* ignore */ });
+
       method = givenSharedStaticMethod(
         function greet(person, cb) {
           if (person === 'error') {

--- a/test/streams.js
+++ b/test/streams.js
@@ -19,7 +19,7 @@ describe('strong-remoting', function() {
   var objects;
 
   beforeEach(function() {
-    objects = RemoteObjects.create();
+    objects = RemoteObjects.create({cors: false});
     remotes = objects.exports;
     app = express();
     app.disable('x-powered-by');
@@ -69,7 +69,7 @@ describe('strong-remoting', function() {
 
 describe('a function returning a ReadableStream', function() {
   var Readable = require('stream').Readable;
-  var remotes = RemoteObjects.create();
+  var remotes = RemoteObjects.create({cors: false});
   var streamClass;
   var server;
   var app;

--- a/test/type.test.js
+++ b/test/type.test.js
@@ -10,7 +10,7 @@ var RemoteObjects = require('../');
 describe('types', function() {
   var remotes;
   beforeEach(function() {
-    remotes = RemoteObjects.create();
+    remotes = RemoteObjects.create({cors: false});
   });
   describe('remotes.defineType(name, fn)', function() {
     it('should define a new type converter', function() {


### PR DESCRIPTION
Push the responsibility of enabling/configuring CORS back to the application developer.

Back-port #352

@richardpringle or @deepakrkris please review