### PR TITLE
Fix support for hooks returning a Promise

### DIFF
--- a/lib/remote-objects.js
+++ b/lib/remote-objects.js
@@ -483,7 +483,7 @@ RemoteObjects.prototype.execHooks = function(when, method, scope, ctx, next) {
       try {
         var result = cur.call(scope, ctx, execStack, method);
         if (result && typeof result.then === 'function') {
-          result.then(function() { next(); }, next);
+          result.then(function() { execStack(); }, next);
         }
       } catch (err) {
         next(err);

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -1905,13 +1905,21 @@ describe('strong-remoting-rest', function() {
 
     it('should resolve promise returned by a hook', function(done) {
       var method = givenSharedPrototypeMethod();
+      var hooksCalled = [];
       objects.before('**', function(ctx) {
-        return new Promise(function(resolve, reject) {
-          resolve('value-to-ignore');
-        });
+        hooksCalled.push('first');
+        return Promise.resolve();
+      });
+      objects.before('**', function(ctx) {
+        hooksCalled.push('second');
+        return Promise.resolve();
       });
 
-      json(method.url).expect(204).end(done);
+      json(method.url).expect(204, function(err, res) {
+        if (err) return done(err);
+        expect(hooksCalled).to.eql(['first', 'second']);
+        return done();
+      });
     });
 
     it('should handle rejected promise returned by a hook', function(done) {


### PR DESCRIPTION
Fix the code to correctly recurse and invoke next hooks after the promise returned by the first hook callback was resolved.

The issue was discovered by @tvdstaaij in https://github.com/strongloop/loopback/pull/2751

@gunjpan @richardpringle or @deepakrkris please review