### PR TITLE
Distinguish between "file" and "File" result types

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -412,9 +412,7 @@ HttpContext.prototype.setReturnArgByName = function(name, value) {
   }
 
   if (returnDesc.root) {
-    // TODO(bajtos) call SharedMethod's convertToBasicRemotingType here?
-    this.resultType = typeof returnDesc.type === 'string' ?
-      returnDesc.type.toLowerCase() : returnDesc.type;
+    this.returnsFile = SharedMethod.isFileType(returnDesc.type);
     return;
   }
 
@@ -651,7 +649,7 @@ HttpContext.prototype.done = function(cb) {
     res.header('Content-Type', operationResults.contentType);
   }
   if (dataExists) {
-    if (this.resultType !== 'file') {
+    if (!this.returnsFile) {
       operationResults.sendBody(res, data, method);
       res.end();
     } else if (Buffer.isBuffer(data) || typeof(data) === 'string') {

--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -404,6 +404,10 @@ function convertToBasicRemotingType(type) {
     type = type.modelName || type.name;
   }
 
+  if (SharedMethod.isFileType(type)) {
+    return 'file';
+  }
+
   type = String(type).toLowerCase();
 
   switch (type) {
@@ -414,7 +418,6 @@ function convertToBasicRemotingType(type) {
     case 'boolean':
     case 'buffer':
     case 'object':
-    case 'file':
     case 'any':
       return type;
     case 'array':
@@ -541,6 +544,12 @@ SharedMethod.convertArg = function(accept, raw) {
   return data;
 };
 
+SharedMethod.isFileType = function(argSpec) {
+  // Only all-lowercase value "file" is recognized as the special file type
+  // Other spellings, most notably "File", are treated as custom types (models)
+  return argSpec === 'file';
+};
+
 /**
  * Returns a reformatted Object valid for consumption as JSON from an Array of
  * results from a remoting function, based on `returns`.
@@ -564,7 +573,7 @@ SharedMethod.toResult = function(returns, raw, ctx) {
 
     if (item.root) {
       var targetType = convertToBasicRemotingType(item.type);
-      var isFile =  targetType === 'file';
+      var isFile = SharedMethod.isFileType(item.type);
       result = isFile ? raw[index] : convert(raw[index], targetType, item.name);
       return false;
     }
@@ -575,7 +584,7 @@ SharedMethod.toResult = function(returns, raw, ctx) {
   returns.forEach(function(item, index) {
     var name = item.name || item.arg;
     var targetType = convertToBasicRemotingType(item.type);
-    if (targetType === 'file') {
+    if (SharedMethod.isFileType(item.type)) {
       g.warn('%s: discarded non-root return argument %s of type "{{file}}"',
         this.stringName,
         name);

--- a/test/http-context.test.js
+++ b/test/http-context.test.js
@@ -86,6 +86,10 @@ describe('HttpContext', function() {
         return JSON.parse(val);
       });
 
+      Dynamic.define('File', function(val) {
+        return JSON.parse(val);
+      });
+
       it('should coerce dynamic type with string prop into object', givenMethodExpectArg({
         type: 'CustomType',
         input: JSON.stringify({ stringProp: 'string' }),
@@ -96,6 +100,12 @@ describe('HttpContext', function() {
         type: 'CustomType',
         input: JSON.stringify({ intProp: 1 }),
         expectedValue: { intProp: 1 }
+      }));
+
+      it('should not coerce File type into file response', givenMethodExpectArg({
+        type: 'File',
+        input: JSON.stringify({ stringProp: 'string' }),
+        expectedValue: { stringProp: 'string' }
       }));
     });
   });


### PR DESCRIPTION
If you have a Loopback model called `File` you'll receive following error when it is set as a return type: `Error: Cannot create a file response from object`

In other words, because `file` is now a reserved keyword with a very specific response handling logic, and `File` is lowercased during normalization into `resultType`, the error above would prevent any Loopback being named `File`. This introduced a breaking change for my apps.

This is loosely related to #318 but in the above case, it's actually not desirable to return a file (buffer/stream) response. Perhaps a more specific keyword than simply `file` would have been better in hindsight.

See also: https://github.com/strongloop/strong-remoting/commit/a85068ef1122751efbbf3e9b2a1b9439ae70fa3f#commitcomment-19410422

@bajtos @richardpringle 