### PR TITLE
Added guard around setting Number.MAX_SAFE_INTEGER for 2.x

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -729,6 +729,7 @@ Number.isInteger = Number.isInteger || function(value) {
     Math.floor(value) === value;
 };
 
+// Cannot assign read only property on Android earlier than 6
 if (typeof Number.MAX_SAFE_INTEGER === 'undefined') {
   Number.MAX_SAFE_INTEGER = Math.pow(2, 53) - 1;
 }

--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -729,7 +729,7 @@ Number.isInteger = Number.isInteger || function(value) {
     Math.floor(value) === value;
 };
 
-if (typeof MAX_SAFE_INTEGER === 'undefined') {
+if (typeof Number.MAX_SAFE_INTEGER === 'undefined') {
   Number.MAX_SAFE_INTEGER = Math.pow(2, 53) - 1;
 }
 

--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -729,7 +729,9 @@ Number.isInteger = Number.isInteger || function(value) {
     Math.floor(value) === value;
 };
 
-Number.MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER || Math.pow(2, 53) - 1;
+if (typeof MAX_SAFE_INTEGER === 'undefined') {
+  Number.MAX_SAFE_INTEGER = Math.pow(2, 53) - 1;
+}
 
 Number.isSafeInteger = Number.isSafeInteger || function(value) {
   return Number.isInteger(value) && Math.abs(value) <= Number.MAX_SAFE_INTEGER;


### PR DESCRIPTION
Trying to set value on a read only variable fails on older web views with the following error:

["Error group: EXCEPTION: Error: Uncaught (in promise): TypeError: Cannot assign to read only property 'MAX_SAFE_INTEGER' of function Number() { [native code] }"]

I have added some guard to make sure it's only set if undefined. This issue was noticed while running on Android 5.0 web views. Works on Android 6.