### PR TITLE
Stop changing read-only Number property

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -732,14 +732,21 @@ SharedMethod.prototype.addAlias = function(alias) {
 };
 
 // To support Node v.0.10.x
-Number.isInteger = Number.isInteger || function(value) {
-  return typeof value === 'number' &&
-    isFinite(value) &&
-    Math.floor(value) === value;
-};
+if (typeof Number.isInteger === 'undefined') {
+  Number.isInteger = function(value) {
+    return typeof value === 'number' &&
+      isFinite(value) &&
+      Math.floor(value) === value;
+  };
+}
 
-Number.MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER || Math.pow(2, 53) - 1;
+if (typeof Number.MAX_SAFE_INTEGER === 'undefined') {
+  Number.MAX_SAFE_INTEGER = Math.pow(2, 53) - 1;
+}
 
-Number.isSafeInteger = Number.isSafeInteger || function(value) {
-  return Number.isInteger(value) && Math.abs(value) <= Number.MAX_SAFE_INTEGER;
-};
+if (typeof Number.isSafeInteger === 'undefined') {
+  Number.isSafeInteger = function(value) {
+    return Number.isInteger(value) &&
+      Math.abs(value) <= Number.MAX_SAFE_INTEGER;
+  };
+}


### PR DESCRIPTION
Trying to set value on a read only variable fails on older web views with the following error:

```
["Error group: EXCEPTION: Error: Uncaught (in promise): TypeError: Cannot assign to read only property 'MAX_SAFE_INTEGER' of function Number() { [native code] }"]
```

I have added some guard to make sure it's only set if undefined. This issue was noticed while running on Android 5.0 web views. Works on Android 6.