### PR TITLE
lockdown dependency for http-auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "grunt-contrib-watch": "^1.0.0",
     "grunt-eslint": "^18.0.0",
     "grunt-karma": "^2.0.0",
-    "http-auth": "^2.2.5",
+    "http-auth": "2.4.11",
     "karma": "^1.2.0",
     "karma-browserify": "^5.1.0",
     "karma-chrome-launcher": "^1.0.1",


### PR DESCRIPTION
Due to a recent release of 2.5.10 which broke node 10/12 support
this commit locks down dependency before 2.5.11 is released
as some registry will still pick up unpublished version (2.5.10)

See http-auth/http-auth@0097ed6195986942a65e14b38b3f30281c9f6435

----
edit found out this is causing node 10/12 to fail too
http-auth/apache-md5@4f3b24d3d382851ab2b72a4132f73a8311473856 😢 