### PR TITLE
[backport #374] lockdown dependency for http-auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "grunt-contrib-watch": "^1.0.0",
     "grunt-jscs": "^3.0.1",
     "grunt-karma": "^2.0.0",
-    "http-auth": "^2.2.5",
+    "http-auth": "2.4.11",
     "karma": "^1.2.0",
     "karma-browserify": "^5.1.0",
     "karma-chrome-launcher": "^1.0.1",


### PR DESCRIPTION
backport of #374 

Due to a recent release of 2.5.10 which broke node 10/12 support
this commit locks down dependency before 2.5.11 is released
as some registry will still pick up unpublished version (2.5.10)
2.4.11 is released with apache-md5, apache-crypt locked down

See http-auth/http-auth/commit/0097ed6195986942a65e14b38b3f30281c9f6435