### PR TITLE
Fix query string to have null

### DIFF
--- a/lib/http-invocation.js
+++ b/lib/http-invocation.js
@@ -171,6 +171,9 @@ HttpInvocation.prototype.createRequest = function() {
   var query;
   var i;
   var auth = this.auth;
+  var opts = {
+    strictNullHandling: true
+  };
 
   // initial url is the format
   req.url = this.base + endpoint.fullPath;
@@ -212,7 +215,7 @@ HttpInvocation.prototype.createRequest = function() {
   }
 
   if (query) {
-    req.url += '?' + qs.stringify(query);
+    req.url += '?' + qs.stringify(query, opts);
   }
 
   return req;

--- a/lib/http-invocation.js
+++ b/lib/http-invocation.js
@@ -21,7 +21,6 @@ var assert = require('assert');
 var request = require('request');
 var Dynamic = require('./dynamic');
 var SUPPORTED_TYPES = ['json', 'application/javascript', 'text/javascript'];
-var qs = require('qs');
 var urlUtil = require('url');
 var ReadableStream = require('stream').Readable;
 var MuxDemux = require('mux-demux');
@@ -171,9 +170,6 @@ HttpInvocation.prototype.createRequest = function() {
   var query;
   var i;
   var auth = this.auth;
-  var opts = {
-    strictNullHandling: true
-  };
 
   // initial url is the format
   req.url = this.base + endpoint.fullPath;
@@ -215,7 +211,11 @@ HttpInvocation.prototype.createRequest = function() {
   }
 
   if (query) {
-    req.url += '?' + qs.stringify(query, opts);
+    var urlParams = Object.keys(query).map(function(key) {
+      return key + '=' + JSON.stringify(query[key]);
+    }).join('&');
+
+    req.url += '?' + encodeURI(urlParams);
   }
 
   return req;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "js2xmlparser": "^1.0.0",
     "loopback-phase": "^1.3.0",
     "mux-demux": "^3.7.9",
-    "qs": "^6.2.1",
     "request": "^2.55.0",
     "sse": "0.0.6",
     "strong-globalize": "^2.6.6",


### PR DESCRIPTION
Fix to allow query string to have null. At the moment doing a find such as below would not work as qs.stringify function would remove the null from the query.

`SomeModel.find({where: {name: null}});`

Instead using JSON.stringify with encodeURI