### PR TITLE
Refuse to override builtin file type

### DIFF
--- a/lib/type-registry.js
+++ b/lib/type-registry.js
@@ -32,6 +32,10 @@ TypeRegistry.prototype.registerType = function(typeName, converter) {
 
   typeName = typeName.toLowerCase();
 
+  if (typeName === 'file') {
+    throw new Error(g.f('Cannot override built-in "{{file}}" type.'));
+  }
+
   if (typeName in this._types) {
     if (this._options.warnWhenOverridingType !== false)
       g.warn('Warning: overriding remoting type %s', typeName);

--- a/test/type-registry.test.js
+++ b/test/type-registry.test.js
@@ -1,0 +1,19 @@
+var expect = require('chai').expect;
+var TypeRegistry = require('../lib/type-registry');
+
+describe('TypeRegistry', function() {
+  var registry;
+  beforeEach(function() {
+    registry = new TypeRegistry();
+  });
+
+  it('refuses to override built-in file type', function() {
+    expect(function() {
+      registry.registerType('File', {
+        fromTypedValue: function() {},
+        fromSloppyValue: function() {},
+        validate: function() {},
+      });
+    }).to.throw(/file/);
+  });
+});


### PR DESCRIPTION
Arguments of `{ type: 'file' }` are handled specially by strong-remoting and don't go through the usual TypeConverter path.

This causes problems in LoopBack applications with a model called "File", which registers a type converter for "file" (the name is case insensitive).

In this patch, we are modifying TypeRegistry to throw an error when the caller attempts to override the built-in "file" type.

Connect to strongloop/loopback#2554

> On the second thought, I think we should add `file` to the list of reserved types and disallow developers to create models called `File`, starting with LoopBack 3.0. It is already not possible to create models like `Object` or `Number`, therefore I think it makes sense to extend this rule to `File` too.
> I believe this will require the smallest amount of code changes and have the lowest maintenance costs in the future.

See also https://github.com/strongloop/strong-remoting/pull/370

@gunjpan or @deepakrkris please review
cc @fabien @ritch 
