### PR TITLE
Rest-adapter errorHandler set content-type `json`

### DIFF
--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -397,6 +397,7 @@ RestAdapter.errorHandler = function(options) {
         err.details = details;
       }
 
+      res.set('content-type', 'application/json');
       res.send({ error: generateResponseError(err) });
 
       function generateResponseError(error) {


### PR DESCRIPTION
the defaultHandler always res.sends an object
therefore make sense to always set response header as such

related to https://github.com/strongloop/loopback-component-storage/pull/179