### PR TITLE
Cache getRestMethodByName to improve performance of remote invocations

### DIFF
--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -143,17 +143,43 @@ RestAdapter.prototype.invoke = function(method, ctorArgs, args, callback) {
   });
 };
 
-RestAdapter.prototype.getRestMethodByName = function(name) {
+/**
+ * creates the rest method by name cache map.
+ * @returns {Object} map of rest method name to rest method
+ */
+RestAdapter.prototype._createRestMethodByNameCache = function() {
+  var restMethodByNameMap = {};
   var classes = this.getClasses();
   for (var i = 0; i < classes.length; i++) {
     var restClass = classes[i];
     for (var j = 0; j < restClass.methods.length; j++) {
       var restMethod = restClass.methods[j];
-      if (restMethod.fullName === name) {
-        return restMethod;
-      }
+      restMethodByNameMap[restMethod.fullName] = restMethod;
     }
   }
+  return restMethodByNameMap;
+};
+
+RestAdapter.prototype.getRestMethodByName = function(name) {
+  var ret;
+  if (this._cachedRestMethodsByName) {
+    ret = this._cachedRestMethodsByName[name];
+  }
+
+  if (!ret) {
+    // Either the method was not found or the cache was not built yet
+    // If the method was not found, then let's rebuild the cache
+    // to see if there were any new methods added
+    this._cachedRestMethodsByName = this._createRestMethodByNameCache();
+    ret = this._cachedRestMethodsByName[name];
+  }
+
+  if (ret && !ret.sharedMethod.sharedClass.isMethodEnabled(ret.sharedMethod)) {
+    // The method was disabled after our cache was built
+    ret = undefined;
+  }
+
+  return ret;
 };
 
 /*!

--- a/test/rest-adapter.test.js
+++ b/test/rest-adapter.test.js
@@ -476,6 +476,61 @@ describe('RestAdapter', function() {
       return new RestAdapter(remotes);
     }
   });
+
+  describe('getRestMethodByName()', function() {
+    var SHARED_CLASS_NAME = 'testClass';
+    var METHOD_NAME = 'testMethod';
+    var FULL_NAME = SHARED_CLASS_NAME + '.' + METHOD_NAME;
+
+    var sharedClass, restAdapter;
+
+    beforeEach(givenSharedClassWithStaticMethod);
+    beforeEach(givenConnectedRestAdapter);
+
+    it('should find method by name', function() {
+      var restMethod = restAdapter.getRestMethodByName(FULL_NAME);
+      expect(restMethod).to.have.property('fullName', FULL_NAME);
+    });
+
+    it('should exclude methods disabled after the cache was built', function() {
+      // Get the rest method to trigger cache rebuild
+      restAdapter.getRestMethodByName(FULL_NAME);
+
+      sharedClass.disableMethodByName(METHOD_NAME);
+
+      var restMethod = restAdapter.getRestMethodByName(FULL_NAME);
+      expect(restAdapter.getRestMethodByName(FULL_NAME)).to.equal(undefined);
+    });
+
+    it('should find methods added after the cache was built', function() {
+      // Get the rest method to trigger cache rebuild
+      restAdapter.getRestMethodByName(FULL_NAME);
+
+      givenStaticSharedMethod('anotherMethod');
+
+      var anotherFullName = SHARED_CLASS_NAME + '.anotherMethod';
+      var restMethod = restAdapter.getRestMethodByName(anotherFullName);
+      expect(restMethod).to.have.property('fullName', anotherFullName);
+    });
+
+    function givenSharedClassWithStaticMethod() {
+      var testClass = { shared: true };
+      sharedClass = new SharedClass(SHARED_CLASS_NAME, testClass);
+      remotes.addClass(sharedClass);
+
+      givenStaticSharedMethod(METHOD_NAME);
+    }
+
+    function givenStaticSharedMethod(name, config) {
+      config = extend({ shared: true, isStatic: true }, config);
+      sharedClass.ctor[name] = extend(function() {}, config);
+    }
+
+    function givenConnectedRestAdapter() {
+      restAdapter = new RestAdapter(remotes);
+      restAdapter.connect('foo');
+    }
+  });
 });
 
 function someFunc() {


### PR DESCRIPTION
This function in RestAdapter is slow due
to creating RestMethods each time.
This can be cached initially, and rechecked
if the entry was not found.

### Description
getRestMethodByName was identified as slow performing when syncing many items across many models. The reason is that each call will iterate through all classes, and create new RestMethods which is slow. 

This optimisation will create a name->RestMethod cache map which is initialised the first time it is called. This way, the look ups are fast. If there is a cache miss, then it will try to refresh the cache (if it hasn't been refreshed already).

#### Related issues
- None

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
