### PR TITLE
Add nyc coverage, report data to coveralls.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 node_modules/
 /coverage/
 dist
+.nyc_output/

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,7 @@
+{
+  "exclude":  [
+    "Gruntfile.js",
+    "test/**/*.js"
+  ],
+  "cache": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ node_js:
   - "4"
   - "6"
   - "7"
+
+after_success: npm run coverage

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
   ],
   "version": "3.1.1",
   "scripts": {
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
     "lint": "grunt eslint",
-    "test": "mocha -R dot",
+    "test": "nyc mocha -R dot",
     "posttest": "npm run lint"
   },
   "engines": {
@@ -42,6 +43,7 @@
     "bluebird": "^3.4.1",
     "browserify": "^13.1.0",
     "chai": "^3.5.0",
+    "coveralls": "^2.11.15",
     "dirty-chai": "^1.2.2",
     "eslint-config-loopback": "^8.0.0",
     "event-stream": "^3.3.1",
@@ -66,6 +68,7 @@
     "karma-requirejs": "^1.0.0",
     "karma-script-launcher": "^1.0.0",
     "mocha": "^3.0.2",
+    "nyc": "^10.1.2",
     "phantomjs-prebuilt": "2.1.11",
     "requirejs": "^2.2.0",
     "socket.io": "^1.4.8",


### PR DESCRIPTION
Based on strongloop/loopback#3165;

 - Modify `npm test` to run all tests with code coverage enabled via `nyc`
 - Add a new script `npm run coverage` to report the coverage to coveralls.io
 - Add a Travis hook `after_success` to run the npm script reporting the coverage

cc @strongloop/loopback-devs 