### PR TITLE
Add nyc coverage, report data to coveralls.io [2.x]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@
 node_modules/
 /coverage/
 dist
-
+.nyc_output/

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,7 @@
+{
+  "exclude":  [
+    "Gruntfile.js",
+    "test/**/*.js"
+  ],
+  "cache": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-  - "iojs"
+  - "4"
+  - "6"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ node_js:
   - "4"
   - "6"
 
+after_success: npm run coverage

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "tag": "lts"
   },
   "scripts": {
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
     "lint": "grunt jscs jshint",
-    "test": "mocha -R dot",
+    "test": "nyc mocha -R dot",
     "posttest": "npm run lint"
   },
   "dependencies": {
@@ -40,6 +41,7 @@
     "bluebird": "^3.4.1",
     "browserify": "^13.1.0",
     "chai": "^3.5.0",
+    "coveralls": "^2.11.15",
     "event-stream": "^3.3.1",
     "eventsource": "^0.2.1",
     "grunt": "^1.0.1",
@@ -63,6 +65,7 @@
     "karma-requirejs": "^1.0.0",
     "karma-script-launcher": "^1.0.0",
     "mocha": "^3.0.2",
+    "nyc": "^10.1.2",
     "requirejs": "^2.2.0",
     "socket.io": "^1.4.8",
     "supertest": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "tag": "lts"
   },
   "scripts": {
-    "pretest": "grunt jscs jshint",
-    "test": "mocha"
+    "lint": "grunt jscs jshint",
+    "test": "mocha -R dot",
+    "posttest": "npm run lint"
   },
   "dependencies": {
     "async": "^2.0.1",


### PR DESCRIPTION

 - Fix Travis-CI platforms - drop io.js, add Node 4 and 6
 - Sync package scripts with master

backport #401:

 - Modify `npm test` to run all tests with code coverage enabled via `nyc`
 - Add a new script `npm run coverage` to report the coverage to coveralls.io
 - Add a Travis hook `after_success` to run the npm script reporting the coverage
