### PR TITLE
Cache getRestMethodByName to improve performance of remote invocations

### DIFF
--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -144,17 +144,43 @@ RestAdapter.prototype.invoke = function(method, ctorArgs, args, callback) {
   });
 };
 
-RestAdapter.prototype.getRestMethodByName = function(name) {
+/**
+ * creates the rest method by name cache map.
+ * @returns {Object} map of rest method name to rest method
+ */
+RestAdapter.prototype._createRestMethodByNameCache = function() {
+  var restMethodByNameMap = {};
   var classes = this.getClasses();
   for (var i = 0; i < classes.length; i++) {
     var restClass = classes[i];
     for (var j = 0; j < restClass.methods.length; j++) {
       var restMethod = restClass.methods[j];
-      if (restMethod.fullName === name) {
-        return restMethod;
-      }
+      restMethodByNameMap[restMethod.fullName] = restMethod;
     }
   }
+  return restMethodByNameMap;
+};
+
+RestAdapter.prototype.getRestMethodByName = function(name) {
+  var ret;
+  if (this._cachedRestMethodsByName) {
+    ret = this._cachedRestMethodsByName[name];
+  }
+
+  if (!ret) {
+    // Either the method was not found or the cache was not built yet
+    // If the method was not found, then let's rebuild the cache
+    // to see if there were any new methods added
+    this._cachedRestMethodsByName = this._createRestMethodByNameCache();
+    ret = this._cachedRestMethodsByName[name];
+  }
+
+  if (ret && !ret.sharedMethod.sharedClass.isMethodEnabled(ret.sharedMethod)) {
+    // The method was disabled after our cache was built
+    ret = undefined;
+  }
+
+  return ret;
 };
 
 /*!


### PR DESCRIPTION
Improve the performance of remote invocation of shared methods
by implementing a cache for looking up remoting metadata of invoked
methods.

Forward-port #400

cc @Traksewt