### PR TITLE
Preserve custom remoting metadata (shared methods)

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -161,6 +161,12 @@ function SharedMethod(fn, name, sc, options) {
   }
 
   this.stringName = (sc ? sc.name : '') + (isStatic ? '.' : '.prototype.') + name;
+
+  // Include any remaining metadata to support custom user-defined extensions
+  for (var key in options) {
+    if (this[key]) continue;
+    this[key] = options[key];
+  }
 }
 
 function normalizeArgumentDescriptor(desc) {

--- a/test/shared-class.test.js
+++ b/test/shared-class.test.js
@@ -155,6 +155,16 @@ describe('SharedClass', function() {
       expect(sc.findMethodByName(METHOD_NAME).accessType).to.eql('READ');
     });
 
+    it('defines a remote method with arbitrary custom metadata', function() {
+      var sc = new SharedClass('SomeClass', SomeClass);
+      SomeClass.prototype.testFn = function() {};
+      sc.defineMethod('testFn', {
+        isStatic: true,
+        accessScope: 'read:custom',
+      });
+      expect(sc.findMethodByName('testFn').accessScope).to.eql('read:custom');
+    });
+
     it('should allow a shared class to resolve dynamically defined functions',
       function(done) {
         var MyClass = function() {};


### PR DESCRIPTION
### Description

Allow strong-remoting dependents like loopback to define custom metadata for shared methods.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to strongloop/loopback#382

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)


cc @strongloop/sq-lb-epitome