### PR TITLE
fix crash on invalid `_format` type. Fixes #396

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -551,7 +551,11 @@ HttpContext.prototype.done = function(cb) {
   }
 
   if (this.req.query._format) {
-    accepts = this.req.query._format.toLowerCase();
+    if (typeof this.req.query._format !== 'string') {
+      accepts = 'invalid'; // this will 406
+    } else {
+      accepts = this.req.query._format.toLowerCase();
+    }
   }
   var dataExists = typeof data !== 'undefined';
   var operationResults = this.resolveReponseOperation(accepts);

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -1507,6 +1507,30 @@ describe('strong-remoting-rest', function() {
             done(err, res);
           });
       });
+
+      it('should return a 400 if _format array', function(done) {
+        var method = givenSharedStaticMethod(
+          function bar(a, cb) {
+            cb(null, a);
+          },
+          {
+            accepts: [
+              {arg: 'a', type: 'object', http: {source: 'body'}},
+            ],
+            returns: {arg: 'data', type: 'object', root: true},
+            http: {path: '/'},
+          }
+        );
+
+        request(app).post(method.classUrl + '?_format=json&_format=xml')
+          .set('Accept', 'application/xml')
+          .set('Content-Type', 'application/json')
+          .send('{"x": 1, "y": "Y"}')
+          .expect(406, function(err, res) {
+            console.log(err);
+            done(err, res);
+          });
+      });
     });
 
     describe('uncaught errors', function() {


### PR DESCRIPTION
### Description

HTTPContext will crash if `_format` is present but not a string.

#### Related issues

#396

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
