### PR TITLE
Add support for app-wide "normalizeHttpPath"

### DIFF
--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -30,6 +30,7 @@ var async = require('async');
 var HttpInvocation = require('./http-invocation');
 var HttpContext = require('./http-context');
 var strongErrorHandler = require('strong-error-handler');
+var inflection = require('inflection');
 
 var json = bodyParser.json;
 var urlencoded = bodyParser.urlencoded;
@@ -69,20 +70,31 @@ RestAdapter.createRestAdapter = function(remotes) {
  * Get the path for the given method.
  */
 
-RestAdapter.prototype.getRoutes = getRoutes;
-function getRoutes(obj) {
-  var routes = obj.http;
+RestAdapter.prototype.getRoutes = function(obj) {
+  return getRoutes(obj, this.options);
+};
 
+function getRoutes(obj, options) {
+  var routes = obj.http;
   if (routes && !Array.isArray(routes)) {
     routes = [routes];
   }
 
-  // overidden
+  // Options of obj (e.g. sharedClass) take precedence over options of adapter
+  const sharedClass = obj.sharedClass || obj;
+  const classOptions = sharedClass.options;
+  var normalize = classOptions && classOptions.normalizeHttpPath;
+  if (normalize === undefined && options) {
+    normalize = options.normalizeHttpPath;
+  }
+  var toPath = normalize ? normalizeHttpPath : untransformedPath;
+
+  // overridden
   if (routes) {
     // patch missing verbs / routes
     routes.forEach(function(r) {
       r.verb = String(r.verb || 'all').toLowerCase();
-      r.path = r.path || ('/' + obj.name);
+      r.path = toPath(r.path || ('/' + obj.name));
     });
   } else {
     if (obj.name === 'sharedCtor') {
@@ -94,12 +106,27 @@ function getRoutes(obj) {
       // build default route
       routes = [{
         verb: 'all',
-        path: obj.name ? ('/' + obj.name) : '',
+        path: obj.name ? toPath('/' + obj.name) : '',
       }];
     }
   }
 
   return routes;
+}
+
+/**
+ * Normalize HTTP path.
+ */
+function normalizeHttpPath(path) {
+  if (typeof path !== 'string') return;
+  return path.replace(/[^\/]+/g, function(match) {
+    if (match.indexOf(':') > -1) return match; // skip placeholders
+    return inflection.transform(match, ['underscore', 'dasherize']);
+  });
+}
+
+function untransformedPath(path) {
+  return path;
 }
 
 RestAdapter.prototype.connect = function(url) {
@@ -122,6 +149,10 @@ RestAdapter.prototype.invoke = function(method, ctorArgs, args, callback) {
 
   var remotes = this.remotes;
   var restMethod = this.getRestMethodByName(method);
+  if (!restMethod) {
+    return callback(new Error(g.f('Cannot invoke unkown method: %s', method)));
+  }
+
   var invocation = new HttpInvocation(
     restMethod, ctorArgs, args, this.connection, remotes.auth, this.typeRegistry
   );
@@ -546,16 +577,17 @@ RestAdapter.prototype.allRoutes = function() {
 };
 
 RestAdapter.prototype.getClasses = function() {
-  return this.remotes.classes(this.options).map(function(c) {
-    return new RestClass(c);
+  return this.remotes.classes(this.options).map(c => {
+    return new RestClass(c, this.options);
   });
 };
 
-function RestClass(sharedClass) {
+function RestClass(sharedClass, adapterOptions) {
   nonEnumerableConstPropery(this, 'sharedClass', sharedClass);
 
   this.name = sharedClass.name;
-  this.routes = getRoutes(sharedClass);
+  this.options = adapterOptions;
+  this.routes = getRoutes(sharedClass, this.options);
 
   this.ctor = sharedClass.sharedCtor &&
     new RestMethod(this, sharedClass.sharedCtor);
@@ -586,7 +618,7 @@ function RestMethod(restClass, sharedMethod) {
   this.notes = sharedMethod.notes;
   this.documented = sharedMethod.documented;
 
-  var methodRoutes = getRoutes(sharedMethod);
+  var methodRoutes = getRoutes(sharedMethod, restClass.options);
   if (sharedMethod.isStatic || !restClass.ctor) {
     this.routes = methodRoutes;
   } else {

--- a/lib/shared-class.js
+++ b/lib/shared-class.js
@@ -20,7 +20,7 @@ module.exports = SharedClass;
 var debug = require('debug')('strong-remoting:shared-class');
 var util = require('util');
 var inherits = util.inherits;
-var inflection = require('inflection');
+var extend = util._extend;
 var SharedMethod = require('./shared-method');
 var assert = require('assert');
 
@@ -36,14 +36,13 @@ var assert = require('assert');
  */
 
 function SharedClass(name, ctor, options) {
-  options = options || {};
   this.name = name || ctor.remoteNamespace;
   this.ctor = ctor;
+  this.options = options;
   this._methods = [];
   this._resolvers = [];
   this._disabledMethods = {};
   var http = ctor && ctor.http;
-  var normalize = options.normalizeHttpPath;
 
   var defaultHttp = {};
   defaultHttp.path = '/' + this.name;
@@ -54,17 +53,9 @@ function SharedClass(name, ctor, options) {
     if (http.length === 0) {
       http.push(defaultHttp);
     }
-    if (normalize) {
-      this.http.forEach(function(h) {
-        h.path = SharedClass.normalizeHttpPath(h.path);
-      });
-    }
   } else {
     // set http.path using the name unless it is defined
-    // TODO(ritch) move http normalization from adapter.getRoutes() to a
-    // better place... eg SharedMethod#getRoutes() or RestClass
     this.http = util._extend(defaultHttp, http);
-    if (normalize) this.http.path = SharedClass.normalizeHttpPath(this.http.path);
   }
 
   if (typeof ctor === 'function' && ctor.sharedCtor) {
@@ -76,18 +67,6 @@ function SharedClass(name, ctor, options) {
   }
   assert(this.name, 'must include a remoteNamespace when creating a SharedClass');
 }
-
-/**
- * Normalize HTTP path.
- */
-
-SharedClass.normalizeHttpPath = function(path) {
-  if (typeof path !== 'string') return;
-  return path.replace(/[^\/]+/g, function(match) {
-    if (match.indexOf(':') > -1) return match; // skip placeholders
-    return inflection.transform(match, ['underscore', 'dasherize']);
-  });
-};
 
 /**
  * Get all shared methods belonging to this shared class.

--- a/test/jsonrpc.test.js
+++ b/test/jsonrpc.test.js
@@ -77,7 +77,7 @@ describe('strong-remoting-jsonrpc', function() {
           });
         };
 
-        var productClass = new SharedClass('product', Product, {});
+        var productClass = new SharedClass('product', Product);
         productClass.defineMethod('getPrice', {isStatic: true});
         objects.addClass(productClass);
       });

--- a/test/rest-adapter.test.js
+++ b/test/rest-adapter.test.js
@@ -300,7 +300,7 @@ describe('RestAdapter', function() {
       remotes.testClass = extend({}, classConfig);
       var fn = remotes.testClass[name] = extend(function() {}, methodConfig);
 
-      var sharedClass = new SharedClass('testClass', remotes.testClass, true);
+      var sharedClass = new SharedClass('testClass', remotes.testClass);
       var restClass = new RestAdapter.RestClass(sharedClass);
 
       var sharedMethod = new SharedMethod(fn, name, sharedClass, methodConfig);
@@ -464,7 +464,7 @@ describe('RestAdapter', function() {
       var testClass = extend({}, classConfig);
       var fn = testClass[name] = extend(function() {}, methodConfig);
 
-      var sharedClass = new SharedClass('testClass', testClass, true);
+      var sharedClass = new SharedClass('testClass', testClass);
       var restClass = new RestAdapter.RestClass(sharedClass);
       remotes.addClass(sharedClass);
 

--- a/test/shared-class.test.js
+++ b/test/shared-class.test.js
@@ -11,6 +11,7 @@ var expect = require('chai').expect;
 var SharedClass = require('../lib/shared-class');
 var factory = require('./helpers/shared-objects-factory.js');
 var RemoteObjects = require('../');
+var RestAdapter = require('../lib/rest-adapter');
 function NOOP() {};
 
 describe('SharedClass', function() {
@@ -31,7 +32,11 @@ describe('SharedClass', function() {
 
     it('fills http.path using a normalized path', function() {
       var sc = new SharedClass('SomeClass', SomeClass, {normalizeHttpPath: true});
-      expect(sc.http.path).to.equal('/some-class');
+      var remotes = RemoteObjects.create();
+      remotes.addClass(sc);
+      var classes = new RestAdapter(remotes).getClasses();
+      expect(classes[0]).to.have.property('routes')
+        .eql([{path: '/some-class', verb: 'all'}]);
     });
 
     it('does not require a sharedConstructor', function() {


### PR DESCRIPTION
### Description

Setting `"normalizeHttpPath"` in `confing.json` currently has no effect on models:

```json
"remoting": {
  "rest": {
    "normalizeHttpPath": true
  }
}
```

This PR addresses this issue by implementing a proposal that @ritch has mentioned in a comment here:

https://github.com/strongloop/strong-remoting/blob/master/lib/shared-class.js#L64

#### Related issues

strongloop/loopback#608
