### PR TITLE
Remote method returned promise args do not respect http.target

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -272,7 +272,7 @@ SharedMethod.prototype.invoke = function(scope, args, remotingOptions, ctx, cb) 
       return retval.then(
         function(args) {
           if (returns.length === 1) args = [args];
-          var result = SharedMethod.toResult(returns, args);
+          var result = SharedMethod.toResult(returns, args, ctx);
           debug('- %s - promise result %j', sharedMethod.name, result);
           cb(null, result);
         },

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -2061,6 +2061,32 @@ describe('strong-remoting-rest', function() {
         json(method.url + '?status=' + exampleStatus)
           .expect(exampleStatus, done);
       });
+      it('returns a custom status code from a promise returned value', function(done) {
+        var exampleStatus = 222;
+        var sentBody = {eiste: 'ligo', kopries: true};
+        var method = givenSharedStaticMethod(
+          function fn() {
+            return Promise.resolve([exampleStatus, sentBody]);
+          },
+          {
+            returns: [{
+              arg: 'status',
+              http: {target: 'status'},
+            }, {
+              arg: 'result',
+              root: true,
+              type: 'object',
+            }],
+          }
+        );
+        json(method.url)
+          .expect(exampleStatus)
+          .then(function(response) {
+            expect(response.body).to.deep.equal(sentBody);
+            done();
+          })
+          .catch(done);
+      });
     });
     it('returns 404 for unknown method of a shared class', function(done) {
       var classUrl = givenSharedStaticMethod().classUrl;

--- a/test/shared-method.test.js
+++ b/test/shared-method.test.js
@@ -389,6 +389,29 @@ describe('SharedMethod', function() {
         });
       });
     });
+    it('should remove from result the targeted value from promise', function(done) {
+      var body = {everything: 'ok'};
+      var method = givenSharedMethod(function() {
+        return Promise.resolve([201, body]);
+      }, {
+        returns: [
+          {arg: 'statusResult', type: 'number', http: {target: 'status'}},
+          {arg: 'result', type: 'object', root: true},
+        ],
+      });
+      var context = ctx(method);
+      // override function that should be provided in HttpContext
+      context.setReturnArgByName = function(name) {
+        return name === 'statusResult';
+      };
+      method.invoke('ctx', {}, {}, context, function(err, result) {
+        setImmediate(function() {
+          expect(result).to.not.have.property('statusResult');
+          expect(result).to.eql(body);
+          done();
+        });
+      });
+    });
   });
 
   function givenSharedMethod(fn, options) {


### PR DESCRIPTION
### Description
When a remote method returns a Promise, the return arguments that should affect status or header  properties are not handled properly

#### Related issues
- #407 
<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
