### PR TITLE
fix: destroy stream result on client close

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -417,6 +417,17 @@ HttpContext.prototype.respondWithEventStream = function(stream) {
   stream.on('end', function() {
     client.send({event: 'end', data: 'null'});
   });
+
+  if (stream.destroy) {
+    // ReadableStream#destroy() was added in Node.js 8.0.0
+    // In earlier versions, some kinds of streams are already
+    // providing this method, which allows us to correctly cancel them.
+    // For streams that do not provide this method, there
+    // is no other reliable way for closing them prematurely.
+    client.once('close', function() {
+      stream.destroy();
+    });
+  }
 };
 
 /**


### PR DESCRIPTION
when SSE connection is closed, destroy PassThrough stream created in createChangeStream()
