### PR TITLE
Use lb access token

### DIFF
--- a/lib/http-invocation.js
+++ b/lib/http-invocation.js
@@ -192,19 +192,27 @@ HttpInvocation.prototype.createRequest = function() {
   req.json = true;
 
   // add auth if it is set
+
   if (auth) {
-    req.auth = {};
     if (auth.username && auth.password) {
+      req.auth = {};
       req.auth.username = auth.username;
       req.auth.password = auth.password;
     }
     if (auth.bearer) {
+      req.auth = req.auth || {};
       req.auth.bearer = auth.bearer;
     }
-    if ('sendImmediately' in auth) {
-      req.auth.sendImmediately = auth.sendImmediately;
-    } else {
-      req.auth.sendImmediately = false;
+    if (req.auth) {
+      if ('sendImmediately' in auth) {
+        req.auth.sendImmediately = auth.sendImmediately;
+      } else {
+        req.auth.sendImmediately = false;
+      }
+    }
+    else if (auth.accessToken) {
+      req.headers = req.headers || {};
+      req.headers.Authorization = auth.accessToken.id;
     }
   }
 

--- a/lib/http-invocation.js
+++ b/lib/http-invocation.js
@@ -209,8 +209,7 @@ HttpInvocation.prototype.createRequest = function() {
       } else {
         req.auth.sendImmediately = false;
       }
-    }
-    else if (auth.accessToken) {
+    } else if (auth.accessToken) {
       req.headers = req.headers || {};
       req.headers.Authorization = auth.accessToken.id;
     }

--- a/lib/remote-objects.js
+++ b/lib/remote-objects.js
@@ -93,9 +93,7 @@ RemoteObjects.extend = function(exports) {
 
 RemoteObjects.prototype.handler = function(name, options) {
   var Adapter = this.adapter(name);
-  // send the set options for this remote object and
-  // the dynamic options passed in to create the adapter
-  var adapter = new Adapter(this, Object.assign({}, this.options, options));
+  var adapter = new Adapter(this, options);
   var handler = adapter.createHandler();
 
   if (handler) {
@@ -134,7 +132,7 @@ RemoteObjects.prototype.connect = function(url, name) {
   }
 
   var Adapter = this.adapter(name);
-  var adapter = new Adapter(this, this.options);
+  var adapter = new Adapter(this);
   this.serverAdapter = adapter;
   return adapter.connect(urlWithoutAuth);
 };

--- a/lib/remote-objects.js
+++ b/lib/remote-objects.js
@@ -93,7 +93,9 @@ RemoteObjects.extend = function(exports) {
 
 RemoteObjects.prototype.handler = function(name, options) {
   var Adapter = this.adapter(name);
-  var adapter = new Adapter(this, options);
+  // send the set options for this remote object and
+  // the dynamic options passed in to create the adapter
+  var adapter = new Adapter(this, Object.assign({}, this.options, options));
   var handler = adapter.createHandler();
 
   if (handler) {
@@ -132,7 +134,7 @@ RemoteObjects.prototype.connect = function(url, name) {
   }
 
   var Adapter = this.adapter(name);
-  var adapter = new Adapter(this);
+  var adapter = new Adapter(this, this.options);
   this.serverAdapter = adapter;
   return adapter.connect(urlWithoutAuth);
 };

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -42,7 +42,6 @@ var urlencoded = bodyParser.urlencoded;
 
 function RestAdapter(remotes, options) {
   EventEmitter.call(this);
-
   this.remotes = remotes;
   this.Context = HttpContext;
   this.options = options || (remotes.options || {}).rest;

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -118,8 +118,6 @@ RestAdapter.prototype._extractAuth = function(remotes, invokeOptions) {
   if (auth || !invokeOptions) return auth;
   if (this.options && this.options.passAccessToken && invokeOptions &&
     invokeOptions.accessToken) {
-    console.log('Got the this.options.passAccessToken: ',
-      this.options.passAccessToken, invokeOptions);
     auth = {
       accessToken: invokeOptions.accessToken
     };
@@ -142,7 +140,6 @@ RestAdapter.prototype.invoke = function(method, ctorArgs, args, callback) {
   }
   var remotes = this.remotes;
   var restMethod = this.getRestMethodByName(method);
-  console.log('the rest method is : ', Object.keys(restMethod));
   var invokeOptions = restMethod.getArgByName('options', args);
   var auth = this._extractAuth(remotes, invokeOptions);
 
@@ -682,10 +679,8 @@ function RestMethod(restClass, sharedMethod) {
  */
 RestMethod.prototype.getArgByName = function(argName, invokedArgs) {
   var argValue;
-  console.log('this.accepts: ', this.accepts);
   if (!this.accepts || !this.accepts.length) return undefined;
   this.accepts.some(function(argProperty, i) {
-    console.log('compare: ', argProperty.arg.toLowerCase() , argName.toLowerCase());
     if (argProperty.arg && argProperty.arg.toLowerCase() === argName.toLowerCase()) {
       argValue = invokedArgs[i];
       return true;

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -111,15 +111,17 @@ RestAdapter.prototype.connect = function(url) {
  * @param args
  * @private
  */
-RestAdapter.prototype._extractAuth = function(remotes, args) {
+RestAdapter.prototype._extractAuth = function(remotes, invokeOptions) {
   var auth = remotes.auth;
-  // check for the loopback options to pass along.
+  // check for the options to pass along to the rest endpoint.
   // It may have the access token that can be used
-  if (auth || !args.length) return auth;
-  var options = args[args.length - 1];
-  if (this.options && this.options.passAccessToken && options && options.accessToken) {
+  if (auth || !invokeOptions) return auth;
+  if (this.options && this.options.passAccessToken && invokeOptions &&
+    invokeOptions.accessToken) {
+    console.log('Got the this.options.passAccessToken: ',
+      this.options.passAccessToken, invokeOptions);
     auth = {
-      accessToken: options.accessToken
+      accessToken: invokeOptions.accessToken
     };
   }
   return auth;
@@ -140,7 +142,9 @@ RestAdapter.prototype.invoke = function(method, ctorArgs, args, callback) {
   }
   var remotes = this.remotes;
   var restMethod = this.getRestMethodByName(method);
-  var auth = this._extractAuth(remotes, args);
+  console.log('the rest method is : ', Object.keys(restMethod));
+  var invokeOptions = restMethod.getArgByName('options', args);
+  var auth = this._extractAuth(remotes, invokeOptions);
 
   var invocation = new HttpInvocation(
     restMethod, ctorArgs, args, this.connection, auth
@@ -669,6 +673,27 @@ function RestMethod(restClass, sharedMethod) {
     });
   }
 }
+
+/**
+ * Get the argument from the invoked arg array by arg name.
+ * @param argName the name of the arg to lookup
+ * @param invokedArgs array
+ * @returns {*} the arg value or undefined if not found
+ */
+RestMethod.prototype.getArgByName = function(argName, invokedArgs) {
+  var argValue;
+  console.log('this.accepts: ', this.accepts);
+  if (!this.accepts || !this.accepts.length) return undefined;
+  this.accepts.some(function(argProperty, i) {
+    console.log('compare: ', argProperty.arg.toLowerCase() , argName.toLowerCase());
+    if (argProperty.arg && argProperty.arg.toLowerCase() === argName.toLowerCase()) {
+      argValue = invokedArgs[i];
+      return true;
+    }
+    return false;
+  });
+  return argValue;
+};
 
 RestMethod.prototype.isReturningArray = function() {
   return this.returns.length == 1 &&

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -121,8 +121,19 @@ RestAdapter.prototype.invoke = function(method, ctorArgs, args, callback) {
 
   var remotes = this.remotes;
   var restMethod = this.getRestMethodByName(method);
+  var auth = remotes.auth;
+  // check for the loopback options to pass along. It may have the access token that can be used
+  if (!auth && args.length) {
+    const options = args[args.length - 1];
+    if (options && options.accessToken ) {
+      auth = {
+        accessToken: options.accessToken
+      }
+    }
+  }
+
   var invocation = new HttpInvocation(
-    restMethod, ctorArgs, args, this.connection, remotes.auth
+    restMethod, ctorArgs, args, this.connection, auth
   );
   var ctx = new ContextBase(restMethod);
   ctx.req = invocation.createRequest();

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -105,6 +105,27 @@ RestAdapter.prototype.connect = function(url) {
   this.connection = url;
 };
 
+/**
+ * Get the auth from the remotes or from the
+ * loopback options if available
+ * @param remotes
+ * @param args
+ */
+RestAdapter.prototype.extractAuth = function(remotes, args) {
+  var auth = remotes.auth;
+  // check for the loopback options to pass along.
+  // It may have the access token that can be used
+  if (!auth && args.length) {
+    var options = args[args.length - 1];
+    if (options && options.accessToken) {
+      auth = {
+        accessToken: options.accessToken
+      };
+    }
+  }
+  return auth;
+};
+
 RestAdapter.prototype.invoke = function(method, ctorArgs, args, callback) {
   assert(this.connection,
     g.f('Cannot invoke method without a connection. See {{RemoteObjects#connect().}}'));
@@ -121,16 +142,7 @@ RestAdapter.prototype.invoke = function(method, ctorArgs, args, callback) {
 
   var remotes = this.remotes;
   var restMethod = this.getRestMethodByName(method);
-  var auth = remotes.auth;
-  // check for the loopback options to pass along. It may have the access token that can be used
-  if (!auth && args.length) {
-    const options = args[args.length - 1];
-    if (options && options.accessToken ) {
-      auth = {
-        accessToken: options.accessToken
-      }
-    }
-  }
+  var auth = this.extractAuth(remotes, args);
 
   var invocation = new HttpInvocation(
     restMethod, ctorArgs, args, this.connection, auth

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -110,18 +110,18 @@ RestAdapter.prototype.connect = function(url) {
  * loopback options if available
  * @param remotes
  * @param args
+ * @private
  */
-RestAdapter.prototype.extractAuth = function(remotes, args) {
+RestAdapter.prototype._extractAuth = function(remotes, args) {
   var auth = remotes.auth;
   // check for the loopback options to pass along.
   // It may have the access token that can be used
-  if (!auth && args.length) {
-    var options = args[args.length - 1];
-    if (options && options.accessToken) {
-      auth = {
-        accessToken: options.accessToken
-      };
-    }
+  if (auth || !args.length) return auth;
+  var options = args[args.length - 1];
+  if (this.options && this.options.passAccessToken && options && options.accessToken) {
+    auth = {
+      accessToken: options.accessToken
+    };
   }
   return auth;
 };
@@ -139,10 +139,9 @@ RestAdapter.prototype.invoke = function(method, ctorArgs, args, callback) {
     args = ctorArgs;
     ctorArgs = [];
   }
-
   var remotes = this.remotes;
   var restMethod = this.getRestMethodByName(method);
-  var auth = this.extractAuth(remotes, args);
+  var auth = this._extractAuth(remotes, args);
 
   var invocation = new HttpInvocation(
     restMethod, ctorArgs, args, this.connection, auth

--- a/test/http-invocation.test.js
+++ b/test/http-invocation.test.js
@@ -198,6 +198,20 @@ describe('HttpInvocation', function() {
       expect(inv.createRequest()).to.eql(expectedReq);
     });
 
+    it('creates a loopback auth request', function() {
+      var inv = givenInvocationForEndpoint(null, [], null,
+        {accessToken: {id: 'abc'}});
+      var expectedReq = { method: 'GET',
+        url: 'http://base/testModel/testMethod',
+        protocol: 'http:',
+        json: true,
+        headers: {
+          Authorization: 'abc'
+        }
+      };
+      expect(inv.createRequest()).to.eql(expectedReq);
+    });
+
     it('makes primitive type arguments as query params', function() {
       var accepts = [
         { arg: 'a', type: 'number' },
@@ -337,14 +351,15 @@ function givenInvocation(method, params) {
       params.auth);
 }
 
-function givenInvocationForEndpoint(accepts, args, verb) {
+function givenInvocationForEndpoint(accepts, args, verb, auth) {
   var method = givenSharedStaticMethod({
     accepts: accepts,
   });
   method.getEndpoints = function() {
     return [createEndpoint({ verb: verb || 'GET' })];
   };
-  return givenInvocation(method, { ctorArgs: [], args: args, baseUrl: 'http://base' });
+  return givenInvocation(method, { ctorArgs: [], args: args,
+    baseUrl: 'http://base', auth: auth });
 }
 
 function createEndpoint(config) {

--- a/test/http-invocation.test.js
+++ b/test/http-invocation.test.js
@@ -209,7 +209,7 @@ describe('HttpInvocation', function() {
           Authorization: 'abc'
         }
       };
-      expect(inv.createRequest()).to.eql(expectedReq);
+      expect(inv.createRequest().headers).to.have.property('Authorization', 'abc');
     });
 
     it('makes primitive type arguments as query params', function() {

--- a/test/rest-adapter.test.js
+++ b/test/rest-adapter.test.js
@@ -198,6 +198,26 @@ describe('RestAdapter', function() {
       });
     });
 
+    describe('getArgByName()', function() {
+      var anArg = [{ arg: 'argName1', type: String }, { arg: 'argName2', type: String }];
+
+      it('should find the first arg', function() {
+        var method = givenRestStaticMethod({accepts: anArg});
+        expect(method.getArgByName('argName1',
+          ['firstArg', 'secondArg'])).to.equal('firstArg');
+      });
+      it('should not find the last arg', function() {
+        var method = givenRestStaticMethod({accepts: anArg});
+        expect(method.getArgByName('argName2',
+          ['firstArg', 'secondArg'])).to.equal('secondArg');
+      });
+      it('should not find the last arg', function() {
+        var method = givenRestStaticMethod({accepts: anArg});
+        expect(method.getArgByName('argName3',
+          ['firstArg', 'secondArg'])).to.equal(undefined);
+      });
+    });
+
     describe('acceptsSingleBodyArgument()', function() {
       it('returns true when the arg is a single Object from body', function() {
         var method = givenRestStaticMethod({
@@ -491,15 +511,13 @@ describe('RestAdapter', function() {
       function() {
         var accessToken = {id: 'def'};
         var options = {accessToken: accessToken};
-        var args = ['a', 'b', 'c', options];
-        var auth = restAdapter._extractAuth(remotes, args);
+        var auth = restAdapter._extractAuth(remotes, options);
         expect(auth).to.deep.equal(options);
       });
     it('should find the auth from the remote',
       function() {
         remotes.auth = {bearer: 'zzz'};
-        var args = ['a', 'b', 'c'];
-        var auth = restAdapter._extractAuth(remotes, args);
+        var auth = restAdapter._extractAuth(remotes, undefined);
         expect(auth).to.deep.equal(remotes.auth);
       });
 
@@ -509,8 +527,7 @@ describe('RestAdapter', function() {
         remotes.auth = {bearer: 'zzz'};
         var accessToken = {id: 'def'};
         var options = {accessToken: accessToken};
-        var args = ['a', 'b', 'c', options];
-        var auth = restAdapter._extractAuth(remotes, args);
+        var auth = restAdapter._extractAuth(remotes, options);
         expect(auth).to.deep.equal(remotes.auth);
       });
   });

--- a/test/rest-adapter.test.js
+++ b/test/rest-adapter.test.js
@@ -477,12 +477,14 @@ describe('RestAdapter', function() {
     }
   });
 
-  describe('extractAuth()', function() {
+  describe('_extractAuth()', function() {
     var remotes;
     var restAdapter;
     beforeEach(function() {
       remotes = RemoteObjects.create({cors: false});
-      restAdapter = new RestAdapter(remotes);
+      restAdapter = new RestAdapter(remotes, {
+        passAccessToken: true
+      });
     });
 
     it('should find the access token in the options from the args',
@@ -490,14 +492,14 @@ describe('RestAdapter', function() {
         var accessToken = {id: 'def'};
         var options = {accessToken: accessToken};
         var args = ['a', 'b', 'c', options];
-        var auth = restAdapter.extractAuth(remotes, args);
+        var auth = restAdapter._extractAuth(remotes, args);
         expect(auth).to.deep.equal(options);
       });
     it('should find the auth from the remote',
       function() {
         remotes.auth = {bearer: 'zzz'};
         var args = ['a', 'b', 'c'];
-        var auth = restAdapter.extractAuth(remotes, args);
+        var auth = restAdapter._extractAuth(remotes, args);
         expect(auth).to.deep.equal(remotes.auth);
       });
 
@@ -508,7 +510,7 @@ describe('RestAdapter', function() {
         var accessToken = {id: 'def'};
         var options = {accessToken: accessToken};
         var args = ['a', 'b', 'c', options];
-        var auth = restAdapter.extractAuth(remotes, args);
+        var auth = restAdapter._extractAuth(remotes, args);
         expect(auth).to.deep.equal(remotes.auth);
       });
   });

--- a/test/rest-adapter.test.js
+++ b/test/rest-adapter.test.js
@@ -477,6 +477,42 @@ describe('RestAdapter', function() {
     }
   });
 
+  describe('extractAuth()', function() {
+    var remotes;
+    var restAdapter;
+    beforeEach(function() {
+      remotes = RemoteObjects.create({cors: false});
+      restAdapter = new RestAdapter(remotes);
+    });
+
+    it('should find the access token in the options from the args',
+      function() {
+        var accessToken = {id: 'def'};
+        var options = {accessToken: accessToken};
+        var args = ['a', 'b', 'c', options];
+        var auth = restAdapter.extractAuth(remotes, args);
+        expect(auth).to.deep.equal(options);
+      });
+    it('should find the auth from the remote',
+      function() {
+        remotes.auth = {bearer: 'zzz'};
+        var args = ['a', 'b', 'c'];
+        var auth = restAdapter.extractAuth(remotes, args);
+        expect(auth).to.deep.equal(remotes.auth);
+      });
+
+    it('should find the auth from the remote, ' +
+      'before looking in the loopback options',
+      function() {
+        remotes.auth = {bearer: 'zzz'};
+        var accessToken = {id: 'def'};
+        var options = {accessToken: accessToken};
+        var args = ['a', 'b', 'c', options];
+        var auth = restAdapter.extractAuth(remotes, args);
+        expect(auth).to.deep.equal(remotes.auth);
+      });
+  });
+
   describe('getRestMethodByName()', function() {
     var SHARED_CLASS_NAME = 'testClass';
     var METHOD_NAME = 'testMethod';


### PR DESCRIPTION
### Description
Allow the rest connector to call other loopback services by passing on the user authorization from the options where available. This is the fallback if no other authorization is specified.

This allows loopback servers to communicate securely with other loopback servers by passing on the auth token. Useful for using loopback as microservices.

#### Related issues
- connect to strongloop/loopback-connector-rest#89
- connect to strongloop/loopback-connector-remote#3

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
