### PR TITLE
Update minimum request version to enforce security fix in tough-cookie dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "loopback-phase": "^1.3.0",
     "mux-demux": "^3.7.9",
     "qs": "^6.2.1",
-    "request": "^2.55.0",
+    "request": "^2.83.0",
     "sse": "0.0.6",
     "strong-error-handler": "^1.0.0",
     "strong-globalize": "^2.6.6",


### PR DESCRIPTION
Update the version of the request dependency, due to a security issue in the tough-cookie library

> The tough-cookie module is vulnerable to regular expression denial of service. Input of around 50k characters is required for a slow down of around 2 seconds.

[tough-cookie vulnerability](https://nodesecurity.io/advisories/525)
[request update](https://github.com/request/request/pull/2776)
