### PR TITLE
Drop support for Node.js versions 0.10 and 0.12 in 2.x branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "6"
+  - "8"
 
 after_success: npm run coverage

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "test": "nyc mocha -R dot",
     "posttest": "npm run lint"
   },
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "dependencies": {
     "async": "^2.0.1",
     "body-parser": "^1.12.4",


### PR DESCRIPTION
Some of our dependencies are no longer supporting pre-4.0 versions of Node.js. As a result, our CI builds are failing on these platforms.

This pull request removes 0.10 and 0.12 from our Travis CI build matrix and also adds "engines" field to package.json to tell our internal Jenkins CI to stop testing 0.10 and 0.12 versions too.

While this may be seen as a controversial move and possibly as a breaking change, I think the impact should be minimum in practice. Both 0.10 and 0.12 versions are not maintained for more than 9 months by now, they are known to contain several security vulnerabilities. Nobody should be running them in production by now. Also note that the "engines" field is by default advisory only and npm install will succeed even on unsupported platforms - see https://docs.npmjs.com/files/package.json#engines

Further reading: https://medium.com/@eranhammer/on-being-operationally-incompetent-4ca4fbccbf98