### PR TITLE
Add support for pass-through authentication 

### DIFF
--- a/lib/http-invocation.js
+++ b/lib/http-invocation.js
@@ -194,9 +194,13 @@ HttpInvocation.prototype.createRequest = function() {
   // the body is json
   req.json = true;
 
-  // add auth if it is set
-  if (auth) {
+  if (auth && auth.accessToken) {
+    // use regular headers to send LoopBack's access token
+    req.headers = req.headers || {};
+    req.headers.Authorization = auth.accessToken.id;
+  } else if (auth) {
     req.auth = {};
+    // add auth if it is set
     if (auth.username && auth.password) {
       req.auth.username = auth.username;
       req.auth.password = auth.password;

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -46,7 +46,7 @@ function RestAdapter(remotes, options) {
 
   this.remotes = remotes;
   this.Context = HttpContext;
-  this.options = options || (remotes.options || {}).rest;
+  this.options = options || (remotes.options || {}).rest || {};
   this.typeRegistry = remotes._typeRegistry;
 }
 
@@ -133,6 +133,32 @@ RestAdapter.prototype.connect = function(url) {
   this.connection = url;
 };
 
+/**
+ *
+ * Get the authorization to use when invoking a remote method.
+ *
+ * @param {Object} invocationOptions The value of the "options" argument
+ *   of the invoked method
+ * @private
+ */
+RestAdapter.prototype._getInvocationAuth = function(invocationOptions) {
+  const auth = this.remotes.auth;
+  if (auth || !this.options.passAccessToken) {
+    // Use the globally-configured authentication credentials
+    return auth;
+  }
+
+  // Check the `options` argument provided by the caller of the invoked method
+  // It may have the access token that can be used
+  const accessToken = invocationOptions && invocationOptions.accessToken;
+  if (accessToken) {
+    return {accessToken};
+  }
+
+  // No authentication credentials are configured.
+  return undefined;
+};
+
 RestAdapter.prototype.invoke = function(method, ctorArgs, args, callback) {
   assert(this.connection,
     g.f('Cannot invoke method without a connection. See {{RemoteObjects#connect().}}'));
@@ -152,9 +178,11 @@ RestAdapter.prototype.invoke = function(method, ctorArgs, args, callback) {
   if (!restMethod) {
     return callback(new Error(g.f('Cannot invoke unkown method: %s', method)));
   }
+  const invokeOptions = restMethod.getArgByName('options', args);
+  const auth = this._getInvocationAuth(invokeOptions);
 
   var invocation = new HttpInvocation(
-    restMethod, ctorArgs, args, this.connection, remotes.auth, this.typeRegistry
+    restMethod, ctorArgs, args, this.connection, auth, this.typeRegistry
   );
   var ctx = invocation.context;
   ctx.req = invocation.createRequest();
@@ -632,6 +660,25 @@ function RestMethod(restClass, sharedMethod) {
     });
   }
 }
+
+/**
+ * Get the argument from the invoked arg array by arg name.
+ * @param argName the name of the arg to lookup
+ * @param invokedArgs array
+ * @returns {*} the arg value or undefined if not found
+ */
+RestMethod.prototype.getArgByName = function(argName, invokedArgs) {
+  let argValue;
+  if (!this.accepts || !this.accepts.length) return undefined;
+  this.accepts.some(function(argProperty, i) {
+    if (argProperty.arg && argProperty.arg.toLowerCase() === argName.toLowerCase()) {
+      argValue = invokedArgs[i];
+      return true;
+    }
+    return false;
+  });
+  return argValue;
+};
 
 RestMethod.prototype.isReturningArray = function() {
   return this.returns.length == 1 &&

--- a/test/http-invocation.test.js
+++ b/test/http-invocation.test.js
@@ -207,6 +207,12 @@ describe('HttpInvocation', function() {
       expect(inv.createRequest()).to.eql(expectedReq);
     });
 
+    it('creates a loopback auth request', function() {
+      const inv = givenInvocationForEndpoint(null, [], null,
+        {accessToken: {id: 'abc'}});
+      expect(inv.createRequest().headers).to.have.property('Authorization', 'abc');
+    });
+
     it('makes primitive type arguments as query params', function() {
       var accepts = [
         {arg: 'a', type: 'number'},
@@ -347,14 +353,19 @@ function givenInvocation(method, params) {
       params.typeRegistry || new TypeRegistry());
 }
 
-function givenInvocationForEndpoint(accepts, args, verb) {
+function givenInvocationForEndpoint(accepts, args, verb, auth) {
   var method = givenSharedStaticMethod({
     accepts: accepts,
   });
   method.getEndpoints = function() {
     return [createEndpoint({verb: verb || 'GET'})];
   };
-  return givenInvocation(method, {ctorArgs: [], args: args, baseUrl: 'http://base'});
+  return givenInvocation(method, {
+    ctorArgs: [],
+    args: args,
+    baseUrl: 'http://base',
+    auth: auth,
+  });
 }
 
 function createEndpoint(config) {


### PR DESCRIPTION
### Description
Allow the rest connector to call other loopback services by passing on the user authorization from the options where available. This is the fallback if no other authorization is specified.

This allows loopback servers to communicate securely with other loopback servers by passing on the auth token. Useful for using loopback as microservices.

#### Related issues
- connect to strongloop/loopback-connector-rest#89
- connect to strongloop/loopback-connector-remote#3
- connect to #421 

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

