### PR TITLE
Avoid setting Content-Type on 304

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -570,7 +570,7 @@ HttpContext.prototype.done = function(cb) {
   }
   var dataExists = typeof data !== 'undefined';
   var operationResults = this.resolveReponseOperation(accepts);
-  if (!res.get('Content-Type')) {
+  if (res.stautsCode !== 304 && !res.get('Content-Type')) {
     res.header('Content-Type', operationResults.contentType);
   }
   if (dataExists) {

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -2376,6 +2376,24 @@ describe('strong-remoting-rest', function() {
       });
   });
 
+  it('does not default content-type to application/json if response is 304', () => {
+    const method = givenSharedStaticMethod(
+      cb => cb(null, {key: 'value'}),
+      {returns: {arg: 'result', type: 'object'}}
+    );
+    return request(app).get(method.url)
+      .expect(200)
+      .then(res => {
+        expect(res.get('Content-type')).to.exist();
+        return request(app).get(method.url)
+        .set('If-None-Match', res.get('etag'))
+        .expect(304);
+      })
+      .then(res => {
+        expect(res.get('Content-type')).to.not.exist();
+      });
+  });
+
   describe('client', function() {
     describe('call of constructor method', function() {
       it('should work', function(done) {


### PR DESCRIPTION
### Description

Fixes a bug where loopback tries to set headers that have already been sent.

Note that express will strip out the `Content-Type` header if the response is 304:

https://github.com/expressjs/express/blob/351396f971280ab79faddcf9782ea50f4e88358d/lib/response.js#L208-L214

Loopback will try to set `Content-Type` to a default (typically `application/json`) if the header does not exist

https://github.com/strongloop/strong-remoting/blob/2153d183be457e8d8f76ca08b79fedb87b387b15/lib/http-context.js#L573-L575

This can lead to a weird edge case when doing tasks like rendering ejs where the following occurs:

Application:
- Tell res to render a template (e.g. an ejs page) from a remote method

Express
- Set some headers including `Content-Type: text/html` since we’re rendering ejs
- Realise that the `statusCode` is `304` so strip out some irrelevant headers including `Content-Type`

Loopback:
- Check to see if we have a `Content-Type` set (which we now don’t because 304 stripped it out)
- Try to set default `Content-Type` to `application/json`

Express:

- Throws error as headers have already been send (unhandled promise rejection)

#### Related issues

Nil

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
