### PR TITLE
feat: remove shared class & type converter

### DIFF
--- a/lib/remote-objects.js
+++ b/lib/remote-objects.js
@@ -233,6 +233,15 @@ RemoteObjects.prototype.addClass = function(sharedClass) {
 };
 
 /**
+ * Remove a previously-registered shared class.
+ *
+ * @param {string} className The name of the shared class to remove.
+ */
+RemoteObjects.prototype.deleteClassByName = function(className) {
+  delete this._classes[className];
+};
+
+/**
  * Find a method by its string name.
  *
  * @param {String} methodString String specifying the method. For example:
@@ -822,6 +831,15 @@ RemoteObjects.prototype.defineType = function(name, converter) {
  */
 RemoteObjects.prototype.defineObjectType = function(name, factoryFn) {
   this._typeRegistry.registerObjectType(name, factoryFn);
+};
+
+/**
+ * Remove a type registered via `defineType` or `defineObjectType`.
+ *
+ * @param {String} name The type name.
+ */
+RemoteObjects.prototype.deleteTypeByName = function(name) {
+  delete this._typeRegistry._types[name.toLowerCase()];
 };
 
 RemoteObjects.convert =

--- a/test/remote-objects.test.js
+++ b/test/remote-objects.test.js
@@ -5,9 +5,10 @@
 
 'use strict';
 
-var expect = require('chai').expect;
-var RemoteObjects = require('../');
-var RestAdapter = require('../lib/rest-adapter');
+const expect = require('chai').expect;
+const RemoteObjects = require('../');
+const RestAdapter = require('../lib/rest-adapter');
+const SharedClass = require('../lib/shared-class');
 
 describe('RemoteObjects', function() {
   var remotes;
@@ -27,6 +28,32 @@ describe('RemoteObjects', function() {
 
     it('should accept a provided adapter if valid', function() {
       remotes.handler(RestAdapter);
+    });
+  });
+
+  describe('deleteClassByName()', () => {
+    it('removes the class', () => {
+      class TempClass {}
+
+      const sharedClass = new SharedClass('TempClass', TempClass);
+      remotes.addClass(sharedClass);
+      expect(Object.keys(remotes._classes)).to.contain('TempClass');
+
+      remotes.deleteClassByName('TempClass');
+      expect(Object.keys(remotes._classes)).to.not.contain('TempClass');
+    });
+  });
+
+  describe('deleteTypeByName()', () => {
+    it('removes the type converter', () => {
+      class MyType {}
+
+      const registeredTypes = remotes._typeRegistry._types;
+      remotes.defineObjectType('MyType', data => new MyType());
+      expect(Object.keys(registeredTypes)).to.contain('mytype');
+
+      remotes.deleteTypeByName('MyType');
+      expect(Object.keys(registeredTypes)).to.not.contain('mytype');
     });
   });
 });


### PR DESCRIPTION
### Description

Add API allowing consumers (e.g. LoopBack) to remove shared class and
type converters (e.g. while removing a LoopBack Model).

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- n/a

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
