### PR TITLE
Update request module version from 2.83.0 to 2.87.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "loopback-phase": "^3.1.0",
     "mux-demux": "^3.7.9",
     "qs": "^6.2.1",
-    "request": "^2.83.0",
+    "request": "^2.87.0",
     "sse": "0.0.8",
     "strong-error-handler": "^2.3.0",
     "strong-globalize": "^3.1.0",


### PR DESCRIPTION
### This fix has been created because latest version of request module does not have dependencies on hawk.

Details here
- connect to https://github.com/strongloop/loopback/issues/3889

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)o new
- [X] Updated dependencies version

@bajtos @virkt25 : Could you please review my code?
