### PR TITLE
Delete remote hooks when class is deleted

### DIFF
--- a/lib/remote-objects.js
+++ b/lib/remote-objects.js
@@ -239,6 +239,9 @@ RemoteObjects.prototype.addClass = function(sharedClass) {
  */
 RemoteObjects.prototype.deleteClassByName = function(className) {
   delete this._classes[className];
+  Object.keys(this.listenerTree).forEach(hooktype=>{
+    delete this.listenerTree[hooktype][className];
+  });
 };
 
 /**

--- a/test/remote-objects.test.js
+++ b/test/remote-objects.test.js
@@ -42,6 +42,20 @@ describe('RemoteObjects', function() {
       remotes.deleteClassByName('TempClass');
       expect(Object.keys(remotes._classes)).to.not.contain('TempClass');
     });
+
+    it('removes the remote hooks', () => {
+      remotes.before('TempClass.' + 'find', function(ctx, next) { next(); });
+      remotes.after('TempClass.' + 'find', function(ctx, next) { next(); });
+      remotes.afterError('TempClass.' + 'find', function(ctx, next) { next(); });
+      expect(Object.keys(remotes.listenerTree.before)).to.contain('TempClass');
+      expect(Object.keys(remotes.listenerTree.after)).to.contain('TempClass');
+      expect(Object.keys(remotes.listenerTree.afterError)).to.contain('TempClass');
+
+      remotes.deleteClassByName('TempClass');
+      expect(Object.keys(remotes.listenerTree.before)).to.not.contain('TempClass');
+      expect(Object.keys(remotes.listenerTree.after)).to.not.contain('TempClass');
+      expect(Object.keys(remotes.listenerTree.afterError)).to.not.contain('TempClass');
+    });
   });
 
   describe('deleteTypeByName()', () => {


### PR DESCRIPTION
### Description
fixing bug that when a class is deleted it's remote methods are not actually removed from app listener tree.

according to discussion [here](https://github.com/strongloop/loopback/pull/3922) this belongs to string remoting, so I reworked the changes here.

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
