### PR TITLE
deleteType support in loopback 2.x

### DIFF
--- a/lib/remote-objects.js
+++ b/lib/remote-objects.js
@@ -732,3 +732,21 @@ RemoteObjects.prototype.defineType =
 RemoteObjects.prototype.convert = function(name, fn) {
   Dynamic.define(name, fn);
 };
+
+/**
+ * Delete a named type conversion.
+ *
+ * ```js
+ * remotes.deleteType('MyType');
+ * ```
+ *
+ * @param {String} name The type name
+ */
+RemoteObjects.prototype.deleteType = function(name) {
+  for (var ix = 0; ix < Dynamic.converters.length; ix++) {
+    if (Dynamic.converters[ix].typeName === name) {
+      Dynamic.converters.splice(ix, 1);
+      break;
+    }
+  }
+};

--- a/test/type.test.js
+++ b/test/type.test.js
@@ -6,6 +6,7 @@
 var assert = require('assert');
 var Dynamic = require('../lib/dynamic');
 var RemoteObjects = require('../');
+var expect = require('chai').expect;
 
 describe('types', function() {
   var remotes;
@@ -19,6 +20,18 @@ describe('types', function() {
         return val;
       });
       assert(Dynamic.getConverter(name));
+    });
+  });
+
+  describe('remotes.deleteType(name, fn)', function() {
+    it('should delete type from existing types', function() {
+      var name = 'DeleteType';
+      remotes.defineType(name, function(val, ctx) {
+        return val;
+      });
+      assert.strictEqual(Dynamic.getConverter(name).typeName, name);
+      remotes.deleteType(name);
+      expect(Dynamic.getConverter(name)).to.be.undefined;
     });
   });
 


### PR DESCRIPTION
### Description
deleteType to remove type from existing types. This is equivalent to deleteType for typeRegistry which exist in loopback 2.x 

#### Related issues

- connect to #453 

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
