### PR TITLE
Fixate event-stream version to 3.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint": "^5.4.0",
     "eslint-config-loopback": "^11.0.0",
     "eslint-plugin-mocha": "^5.0.0",
-    "event-stream": "^3.3.1",
+    "event-stream": "3.3.1",
     "eventsource": "^1.0.5",
     "http-auth": "^3.0.1",
     "mocha": "^5.2.0",


### PR DESCRIPTION
See https://snyk.io/blog/malicious-code-found-in-npm-package-event-stream
