### PR TITLE
Lock event-stream to 3.3.1 for 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "bluebird": "^3.4.1",
     "chai": "^3.5.0",
     "coveralls": "^3.0.1",
-    "event-stream": "^3.3.1",
+    "event-stream": "3.3.1",
     "eventsource": "^0.2.1",
     "http-auth": "2.4.11",
     "jscs": "^3.0.7",


### PR DESCRIPTION
See related discussion in https://github.com/strongloop/strong-remoting/pull/458