### PR TITLE
Drop support for Node.js 6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "10"
   - "12"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "posttest": "npm run lint"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "dependencies": {
     "async": "^2.0.1",


### PR DESCRIPTION
It has reached end-of-life long time ago plus `loopback` does no support
it either - see https://github.com/strongloop/loopback/pull/4194

