### PR TITLE
Update dependencies to their latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     "node": ">=8"
   },
   "dependencies": {
-    "async": "^2.0.1",
+    "async": "^3.1.0",
     "body-parser": "^1.12.4",
-    "debug": "^3.1.0",
-    "depd": "^1.1.0",
-    "escape-string-regexp": "^1.0.5",
+    "debug": "^4.1.1",
+    "depd": "^2.0.0",
+    "escape-string-regexp": "^2.0.0",
     "eventemitter2": "^5.0.1",
     "express": "4.x",
     "inflection": "^1.7.1",
@@ -36,7 +36,7 @@
     "request": "^2.83.0",
     "sse": "0.0.8",
     "strong-error-handler": "^3.0.0",
-    "strong-globalize": "^4.1.0",
+    "strong-globalize": "^5.0.2",
     "traverse": "^0.6.6",
     "xml2js": "^0.4.8"
   },
@@ -48,14 +48,14 @@
     "eslint": "^5.4.0",
     "eslint-config-loopback": "^11.0.0",
     "eslint-plugin-mocha": "^5.0.0",
-    "event-stream": "3.3.1",
+    "event-stream": "^4.0.1",
     "eventsource": "^1.0.5",
     "http-auth": "^3.0.1",
-    "mocha": "^5.2.0",
-    "nyc": "^12.0.2",
+    "mocha": "^6.2.1",
+    "nyc": "^14.1.1",
     "requirejs": "^2.2.0",
     "socket.io": "^2.1.1",
-    "supertest": "^3.1.0"
+    "supertest": "^4.0.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Dependencies not updated:
 - jayson: v4 breaks our test suite
 - js2xmlparser: release notes mention changes in generated output,
   I don't want to break existing LoopBack clients

Before this change, `npm install` reported:

    found 32 vulnerabilities (31 high, 1 critical)

This commit removes all (known) vulnerabilities:

    found 0 vulnerabilities

Signed-off-by: Miroslav Bajtoš <mbajtoss@gmail.com>

I am also leaving out `eslint` upgrade, see https://github.com/strongloop/strong-remoting/pull/470