### PR TITLE
Fix handling of anonymous object types

### DIFF
--- a/lib/http-invocation.js
+++ b/lib/http-invocation.js
@@ -280,7 +280,11 @@ HttpInvocation.prototype.invoke = function(callback) {
     }
     if (err) return callback(err);
     self.res = self.context.res = res;
-    self.transformResponse(res, body, callback);
+    try {
+      self.transformResponse(res, body, callback);
+    } catch (err) {
+      callback(err);
+    }
   });
 };
 

--- a/lib/type-registry.js
+++ b/lib/type-registry.js
@@ -80,8 +80,16 @@ TypeRegistry.prototype.registerObjectType = function(typeName, factoryFn) {
 };
 
 TypeRegistry.prototype.getConverter = function(type) {
+  const isAnonynousObjectTypeDefinition = typeof type === 'object' &&
+    Object.getPrototypeOf(type) === Object.prototype;
+
+  if (isAnonynousObjectTypeDefinition) {
+    debug('Treating inline object definition as a free-form object:', type);
+    type = 'object';
+  }
+
   assert(typeof type === 'string' || Array.isArray(type),
-    'type must be either an array or a string.');
+    '"type" must be an array, a string or an object (an inline definition).');
 
   if (type === 'array')
     type = ['any'];

--- a/test/rest.browser.test.js
+++ b/test/rest.browser.test.js
@@ -29,7 +29,9 @@ describe('strong-remoting-rest', function() {
 
   // setup
   beforeEach(function() {
-    objects = RemoteObjects.create();
+    objects = RemoteObjects.create({
+      errorHandler: {debug: true},
+    });
     remotes = objects.exports;
 
     // connect to the app
@@ -323,6 +325,34 @@ describe('strong-remoting-rest', function() {
 
         objects.invoke(method.name, ['', false, 0], function(err, a, b, c) {
           expect(err).to.be.an.instanceof(Error);
+          done();
+        });
+      });
+
+      it('handles anonymous object types in the response', (done) => {
+        const method = givenSharedStaticMethod(
+          function updateAll(cb) {
+            cb(null, {count: 1});
+          },
+          // See LoopBack's PersistedModel.updateAll method
+          {
+            returns: {
+              arg: 'info',
+              type: {
+                count: {
+                  type: 'number',
+                  description: 'The number of instances updated',
+                },
+              },
+              root: true,
+            },
+            http: {path: '/'},
+          }
+        );
+
+        objects.invoke(method.name, [], (err, result) => {
+          if (err) return done(err);
+          expect(result).to.eql({count: 1});
           done();
         });
       });


### PR DESCRIPTION
In LoopBack, the method `PersistedModel.updateAll` describes the return type using an inline (anonymous) definition:

```
{
  returns: {
    arg: 'info',
    type: {
      count: {
        type: 'number',
        description: 'The number of instances updated',
      },
    },
    root: true,
  },
}
```

Before this change, remote invocation of updateAll was crashing the process with the following error:

```
AssertionError: type must be either an array or a string.
```

This patch fixes the problem as follows:

- A try/catch block is introduced to correctly report any sync errors via the callback

- The type registry was improved to recognize anonymous object types and use the "object" converter for them.

#### Related issues

Fixes https://github.com/strongloop/loopback/issues/3717

/cc @angfal @ewrayjohnson

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
