### PR TITLE
Forward http definition to REST routes

### DIFF
--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -601,6 +601,7 @@ RestAdapter.prototype.allRoutes = function() {
       accepts: (method.accepts && method.accepts.length) ? method.accepts : undefined,
       returns: (method.returns && method.returns.length) ? method.returns : undefined,
       errors: (method.errors && method.errors.length) ? method.errors : undefined,
+      http: method.http,
     });
   }
 };

--- a/test/rest-adapter.test.js
+++ b/test/rest-adapter.test.js
@@ -584,6 +584,18 @@ describe('RestAdapter', function() {
       restAdapter.connect('foo');
     }
   });
+
+  describe('allRoutes', function() {
+    it('includes http', function() {
+      const remotes = RemoteObjects.create({cors: false});
+      remotes.exports.testClass = factory.createSharedClass();
+      remotes.exports.testClass.http = {path: '/testClass', verb: 'any'};
+
+      const restAdapter = new RestAdapter(remotes);
+      const allRoutes = restAdapter.allRoutes();
+      expect(allRoutes[0]).to.have.property('http');
+    });
+  });
 });
 
 function someFunc() {


### PR DESCRIPTION
fixes #464

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/strong-remoting) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)

Probably `loopback-swagger` needs an update too. Now that `route.http` is defined [route-helper](https://github.com/strongloop/loopback-swagger/blob/master/lib/specgen/route-helper.js#L213-L221) expects also `errorStatus` to be defined and displays an undefined error.
![grafik](https://user-images.githubusercontent.com/815915/66584508-9422d800-eb85-11e9-9e12-9ccdeabe4c4c.png)
