### PR TITLE
Fix misleaded property definitions

### DIFF
--- a/lib/shared-method.js
+++ b/lib/shared-method.js
@@ -37,8 +37,8 @@ const isSafeInteger = numberChecks.isSafeInteger;
  * @property {String} notes Additional notes, used by API documentation generators like
  * Swagger.
  * @property {String} http
- * @property {String} rest
- * @property {String} shared
+ * @property {Object} rest
+ * @property {Boolean} shared
  * @property {Boolean} [documented] Default: true. Set to `false` to exclude the method
  * from Swagger metadata.
  *
@@ -179,7 +179,7 @@ function normalizeArgumentDescriptor(desc) {
  * all the method options.
  *
  * @param {Function} fn
- * @param {Function} name
+ * @param {String} name
  * @param {SharedClass} SharedClass
  * @param {Boolean} isStatic
  */


### PR DESCRIPTION
Fixes wrong type definitions in documentation for the arguments of `SharedMethod` and `SharedMethod.fromFunction`.

Fixes #462 

- [x] `npm test` passes on your machine
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
- [ ] **Not necessary** - New tests added or existing tests modified to cover all changes

