### PR TITLE
Content-Type should be optional for all 3xx redirects

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -576,7 +576,7 @@ HttpContext.prototype.done = function(cb) {
   }
   const dataExists = typeof data !== 'undefined';
   const operationResults = this.resolveReponseOperation(accepts);
-  if (res.statusCode !== 304 && !res.get('Content-Type')) {
+  if ((res.statusCode < 300 || res.statusCode > 399) && !res.get('Content-Type')) {
     res.header('Content-Type', operationResults.contentType);
   }
   if (dataExists) {

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -2447,6 +2447,22 @@ describe('strong-remoting-rest', function() {
       });
   });
 
+  it('does not default content-type to application/json if response is 302', () => {
+    const method = givenSharedStaticMethod(
+      (res) => {
+        res.status(302).end();
+        return Promise.resolve({});
+      },
+      {accepts: {arg: 'res', type: 'object', http: {source: 'res'}}},
+    );
+
+    return request(app).get(method.url)
+      .expect(302)
+      .then(res => {
+        expect(res.get('Content-type')).to.not.exist();
+      });
+  });
+
   describe('client', function() {
     describe('call of constructor method', function() {
       it('should work', function(done) {


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

When response is a redirect (302 by default), for example `await options.httpContext.res.redirect(redirectUrl)` generates following error

```
(node:8972) UnhandledPromiseRejectionWarning: Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
    at ServerResponse.setHeader (_http_outgoing.js:541:11)
    at ServerResponse.header (C:\Users\x\myProject\node_modules\express\lib\response.js:771:10)
    at HttpContext.done (C:\Users\x\myProject\node_modules\strong-remoting\lib\http-context.js:574:9)
    ...
```
This PR makes _Content-Type_ header optional since message body is optional for redirects.


## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/strong-remoting) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
