### PR TITLE
Account for / routes in RestAdapter.allRoutes

### DIFF
--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -584,7 +584,7 @@ RestAdapter.prototype.allRoutes = function() {
       path = currentRoot + path;
     }
 
-    if (path[path.length - 1] === '/') {
+    if (path.length > 1 && path[path.length - 1] === '/') {
       path = path.substr(0, path.length - 1);
     }
 

--- a/test/rest-adapter.test.js
+++ b/test/rest-adapter.test.js
@@ -595,6 +595,18 @@ describe('RestAdapter', function() {
       const allRoutes = restAdapter.allRoutes();
       expect(allRoutes[0]).to.have.property('http');
     });
+
+    it('does not alter / paths', function() {
+      const remotes = RemoteObjects.create({cors: false});
+      remotes.exports.testClass = factory.createSharedClass();
+      remotes.exports.testClass.http = {path: '/', verb: 'any'};
+      remotes.exports.testClass.sharedCtor.accepts = [];
+      remotes.exports.testClass.sharedCtor.http = {path: '/', verb: 'patch'};
+
+      const restAdapter = new RestAdapter(remotes);
+      const allRoutes = restAdapter.allRoutes();
+      expect(allRoutes[0].path).to.equal('/');
+    });
   });
 });
 


### PR DESCRIPTION
Previously, there was a bug in RestAdapter.allRoutes where the paths for routes which were mounted at `/` would return as empty instead of the expected `/` because of some trailing slash removal logic that was faulty. This commit fixes this so that it accounts for cases where the path itself is `/`, so the logic will leave those unchanged.

Fixes strongloop/strong-remoting#487

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/strong-remoting) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
